### PR TITLE
feat: 인증 시스템 개선 및 온보딩 키워드 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ app.*.map.json
 
 # Environment variables
 .env
+
+# Docs
+/docs/

--- a/lib/core/config/prefs.dart
+++ b/lib/core/config/prefs.dart
@@ -18,13 +18,9 @@ class Prefs {
 
   static const String _accessTokenKey = 'access_token';
   static const String _refreshTokenKey = 'refresh_token';
-  static const String _accessTokenExpiryKey = 'access_token_expiry';
-  static const String _refreshTokenExpiryKey = 'refresh_token_expiry';
 
   String? get accessToken => prefs.getString(_accessTokenKey);
   String? get refreshToken => prefs.getString(_refreshTokenKey);
-  int? get accessTokenExpiry => prefs.getInt(_accessTokenExpiryKey);
-  int? get refreshTokenExpiry => prefs.getInt(_refreshTokenExpiryKey);
 
   Future<void> setAccessToken(String? value) async {
     if (value == null) {
@@ -42,29 +38,11 @@ class Prefs {
     }
   }
 
-  Future<void> setAccessTokenExpiry(int? value) async {
-    if (value == null) {
-      await prefs.remove(_accessTokenExpiryKey);
-    } else {
-      await prefs.setInt(_accessTokenExpiryKey, value);
-    }
-  }
-
-  Future<void> setRefreshTokenExpiry(int? value) async {
-    if (value == null) {
-      await prefs.remove(_refreshTokenExpiryKey);
-    } else {
-      await prefs.setInt(_refreshTokenExpiryKey, value);
-    }
-  }
-
   /// 모든 인증 관련 데이터 삭제
   Future<void> clearAuthData() async {
     await Future.wait([
       prefs.remove(_accessTokenKey),
       prefs.remove(_refreshTokenKey),
-      prefs.remove(_accessTokenExpiryKey),
-      prefs.remove(_refreshTokenExpiryKey),
     ]);
   }
 }

--- a/lib/core/config/provider_config.dart
+++ b/lib/core/config/provider_config.dart
@@ -3,10 +3,16 @@ import 'package:arttrip/core/network/network.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/features/home/home_repository_mock.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/features/onboarding/data/keywords_repository.dart';
+import 'package:arttrip/features/onboarding/data/keywords_repository_mock.dart';
+import 'package:arttrip/features/onboarding/viewmodel/keywords_viewmodel.dart';
 import 'package:provider/provider.dart';
 
 final List<ChangeNotifierProvider> getProviders = [
   ChangeNotifierProvider<HomeViewModel>(
     create: (_) => HomeViewModel(AppConsts.useMock ? HomeRepositoryMockImpl() : HomeRepositoryImpl(DioClient.instance)),
+  ),
+  ChangeNotifierProvider<KeywordsViewModel>(
+    create: (_) => KeywordsViewModel(AppConsts.useMock ? KeywordsRepositoryMockImpl() : KeywordsRepositoryImpl(DioClient.instance)),
   ),
 ];

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,11 +1,11 @@
 import 'package:arttrip/core/network/api_result.dart';
 import 'package:arttrip/core/network/interceptors/auth_interceptor.dart';
 import 'package:arttrip/core/network/interceptors/error_interceptor.dart';
+import 'package:arttrip/core/network/interceptors/logging_interceptor.dart';
 import 'package:arttrip/core/network/interceptors/retry_interceptor.dart';
 import 'package:arttrip/core/network/network_exceptions.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 /// Dio 클라이언트 설정 옵션
 class DioClientOptions {
@@ -90,29 +90,19 @@ class DioClient {
     );
 
     // 인터셉터 순서가 중요!
-    // 1. 로깅 (요청 시작 로그)
-    // 2. 인증 (토큰 추가)
+    // 1. 인증 (토큰 추가) - 먼저 실행되어야 로그에 토큰이 포함됨
+    // 2. 로깅 (요청/응답 로그)
     // 3. 재시도 (실패 시 재요청)
     // 4. 에러 핸들링 (최종 에러 변환)
 
-    // 로깅 인터셉터 (디버그 모드에서만)
-    if (options.enableLogging && kDebugMode) {
-      _dio.interceptors.add(
-        PrettyDioLogger(
-          requestHeader: true,
-          requestBody: true,
-          responseHeader: false,
-          responseBody: true,
-          error: true,
-          compact: true,
-          maxWidth: 90,
-        ),
-      );
-    }
-
-    // 인증 인터셉터
+    // 인증 인터셉터 (먼저 추가)
     if (authInterceptor != null) {
       _dio.interceptors.add(authInterceptor);
+    }
+
+    // 로깅 인터셉터 (디버그 모드에서만)
+    if (options.enableLogging && kDebugMode) {
+      _dio.interceptors.add(LoggingInterceptor());
     }
 
     // 재시도 인터셉터

--- a/lib/core/network/interceptors/auth_interceptor.dart
+++ b/lib/core/network/interceptors/auth_interceptor.dart
@@ -64,6 +64,15 @@ class AuthInterceptor extends Interceptor {
       return handler.next(err);
     }
 
+    // 응답 body에서 code 확인
+    var errorCode = _extractErrorCode(err.response);
+
+    // JWT401-EXPIRED_ACCESS만 토큰 갱신 시도, 나머지는 바로 로그아웃
+    if (errorCode != 'JWT401-EXPIRED_ACCESS') {
+      await onTokenExpired();
+      return handler.next(err);
+    }
+
     // 이미 토큰 갱신 중이면 대기열에 추가
     if (_isRefreshing) {
       return _queueRequest(err.requestOptions, handler);
@@ -97,6 +106,20 @@ class AuthInterceptor extends Interceptor {
     } finally {
       _isRefreshing = false;
     }
+  }
+
+  /// 응답에서 에러 코드 추출
+  String? _extractErrorCode(Response<dynamic>? response) {
+    if (response?.data == null) return null;
+
+    try {
+      var data = response!.data;
+      if (data is Map<String, dynamic>) {
+        return data['code'] as String?;
+      }
+    } catch (_) {}
+
+    return null;
   }
 
   /// 토큰이 필요 없는 공개 엔드포인트인지 확인

--- a/lib/core/network/interceptors/error_interceptor.dart
+++ b/lib/core/network/interceptors/error_interceptor.dart
@@ -56,6 +56,14 @@ class ErrorInterceptor extends Interceptor {
       buffer.writeln('║ Response Data: ${err.response?.data}');
     }
 
+    // 실제 에러 원인 출력
+    if (err.error != null) {
+      buffer.writeln('║ Original Error: ${err.error}');
+    }
+    if (err.message != null) {
+      buffer.writeln('║ Dio Message: ${err.message}');
+    }
+
     buffer.writeln('╚══════════════════════════════════════════════════════════');
 
     // ignore: avoid_print

--- a/lib/core/network/interceptors/logging_interceptor.dart
+++ b/lib/core/network/interceptors/logging_interceptor.dart
@@ -1,0 +1,43 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// 간단한 한 줄 로깅 인터셉터
+class LoggingInterceptor extends Interceptor {
+  LoggingInterceptor({this.enableRequestBody = false});
+
+  /// 요청 body 출력 여부
+  final bool enableRequestBody;
+
+  /// 요청 시작 시간 저장
+  final Map<int, DateTime> _requestTimes = {};
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    _requestTimes[options.hashCode] = DateTime.now();
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    _log(response.requestOptions, response.statusCode, isError: false);
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    _log(err.requestOptions, err.response?.statusCode, isError: true);
+    handler.next(err);
+  }
+
+  void _log(RequestOptions options, int? statusCode, {required bool isError}) {
+    var startTime = _requestTimes.remove(options.hashCode);
+    var duration = startTime != null ? DateTime.now().difference(startTime).inMilliseconds : 0;
+
+    var method = options.method.padRight(6);
+    var path = options.path;
+    var status = statusCode?.toString() ?? 'ERR';
+    var icon = isError ? '✗' : '✓';
+
+    debugPrint('[API] $icon $method $path → $status (${duration}ms)');
+  }
+}

--- a/lib/core/network/interceptors/retry_interceptor.dart
+++ b/lib/core/network/interceptors/retry_interceptor.dart
@@ -85,6 +85,11 @@ class RetryInterceptor extends Interceptor {
       return false;
     }
 
+    // 재시도하지 않을 경로
+    if (_isNoRetryPath(err.requestOptions.path)) {
+      return false;
+    }
+
     // 타임아웃 에러는 재시도
     if (_isTimeoutError(err)) {
       return true;
@@ -102,6 +107,15 @@ class RetryInterceptor extends Interceptor {
     }
 
     return false;
+  }
+
+  /// 재시도하지 않을 경로인지 확인
+  bool _isNoRetryPath(String path) {
+    const noRetryPaths = [
+      '/auth/app/logout',
+      '/auth/social',
+    ];
+    return noRetryPaths.any((p) => path.contains(p));
   }
 
   /// 타임아웃 에러인지 확인

--- a/lib/core/network/models/api_response.dart
+++ b/lib/core/network/models/api_response.dart
@@ -1,0 +1,33 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'api_response.g.dart';
+
+/// API 공통 응답 래퍼
+///
+/// 서버의 모든 응답이 이 형식을 따름:
+/// - isSuccess: 성공 여부
+/// - code: 응답 코드 (에러 코드 포함)
+/// - message: 응답 메시지
+/// - result: 실제 데이터 (nullable)
+@JsonSerializable(genericArgumentFactories: true)
+class ApiResponse<T> {
+  const ApiResponse({
+    required this.isSuccess,
+    required this.code,
+    required this.message,
+    this.result,
+  });
+
+  factory ApiResponse.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object? json) fromJsonT,
+  ) =>
+      _$ApiResponseFromJson(json, fromJsonT);
+
+  final bool isSuccess;
+  final String code;
+  final String message;
+  final T? result;
+
+  Map<String, dynamic> toJson(Object? Function(T value) toJsonT) => _$ApiResponseToJson(this, toJsonT);
+}

--- a/lib/features/auth/data/auth_api_service.dart
+++ b/lib/features/auth/data/auth_api_service.dart
@@ -1,4 +1,9 @@
+import 'package:arttrip/core/env.dart';
+import 'package:arttrip/core/network/models/api_response.dart';
 import 'package:arttrip/core/network/network.dart';
+import 'package:arttrip/features/auth/data/models/auth_token_result.dart';
+import 'package:arttrip/features/auth/service/token_storage_service.dart';
+import 'package:dio/dio.dart';
 
 /// 인증 관련 API 서비스
 class AuthApiService extends BaseApiService {
@@ -8,11 +13,11 @@ class AuthApiService extends BaseApiService {
   ///
   /// [provider] - 소셜 로그인 제공자 (KAKAO, GOOGLE, APPLE)
   /// [idToken] - 소셜 로그인에서 받은 토큰
-  Future<ApiResult<AuthTokenResponse>> socialLogin({
+  Future<ApiResult<ApiResponse<AuthTokenResult>>> socialLogin({
     required String provider,
     required String idToken,
   }) {
-    return post<AuthTokenResponse>(
+    return post<ApiResponse<AuthTokenResult>>(
       '/auth/social',
       data: {
         'provider': provider,
@@ -20,8 +25,10 @@ class AuthApiService extends BaseApiService {
       },
       fromJson: (data) {
         var json = data as Map<String, dynamic>;
-        var result = json['result'] as Map<String, dynamic>?;
-        return AuthTokenResponse.fromJson(result ?? json);
+        return ApiResponse.fromJson(
+          json,
+          (obj) => AuthTokenResult.fromJson(obj as Map<String, dynamic>),
+        );
       },
     );
   }
@@ -29,64 +36,45 @@ class AuthApiService extends BaseApiService {
   /// 토큰 갱신 (재발행)
   ///
   /// [refreshToken] - 갱신에 사용할 리프레시 토큰
-  Future<ApiResult<AuthTokenResponse>> refreshToken({
+  Future<ApiResult<ApiResponse<AuthTokenResult>>> refreshToken({
     required String refreshToken,
   }) {
-    return post<AuthTokenResponse>(
+    return post<ApiResponse<AuthTokenResult>>(
       '/auth/app/reissue',
       data: {
         'refreshToken': refreshToken,
       },
       fromJson: (data) {
         var json = data as Map<String, dynamic>;
-        var result = json['result'] as Map<String, dynamic>?;
-        return AuthTokenResponse.fromJson(result ?? json);
+        return ApiResponse.fromJson(
+          json,
+          (obj) => AuthTokenResult.fromJson(obj as Map<String, dynamic>),
+        );
       },
     );
   }
 
   /// 로그아웃
-  Future<ApiResult<void>> logout() async {
-    var result = await post<Object?>('/auth/logout');
-    return result.map((_) {});
-  }
-}
+  ///
+  /// [refreshToken] - 로그아웃할 리프레시 토큰
+  /// 인터셉터를 거치지 않도록 별도 Dio 인스턴스 사용 (무한 루프 방지)
+  Future<ApiResult<void>> logout({required String refreshToken}) async {
+    try {
+      var accessToken = TokenStorageService.instance.getAccessToken();
+      var dio = Dio(BaseOptions(
+        baseUrl: Env.apiBaseUrl,
+        headers: {
+          'Content-Type': 'application/json',
+          if (accessToken != null) 'Authorization': 'Bearer $accessToken',
+        },
+      ));
 
-/// 인증 토큰 응답 모델
-class AuthTokenResponse {
-  const AuthTokenResponse({
-    required this.accessToken,
-    required this.refreshToken,
-    this.expiresIn,
-    this.tokenType = 'Bearer',
-  });
-
-  factory AuthTokenResponse.fromJson(Map<String, dynamic> json) {
-    return AuthTokenResponse(
-      accessToken: json['accessToken'] as String,
-      refreshToken: json['refreshToken'] as String,
-      expiresIn: json['expiresIn'] as int?,
-      tokenType: json['tokenType'] as String? ?? 'Bearer',
-    );
-  }
-
-  final String accessToken;
-  final String refreshToken;
-  final int? expiresIn;
-  final String tokenType;
-
-  Map<String, dynamic> toJson() {
-    return {
-      'accessToken': accessToken,
-      'refreshToken': refreshToken,
-      if (expiresIn != null) 'expiresIn': expiresIn,
-      'tokenType': tokenType,
-    };
-  }
-
-  @override
-  String toString() {
-    return 'AuthTokenResponse(accessToken: ${accessToken.substring(0, 10)}..., refreshToken: ${refreshToken.substring(0, 10)}...)';
+      await dio.post('/auth/app/logout', data: {'refreshToken': refreshToken});
+      return ApiResult.success(null);
+    } catch (e) {
+      // 로그아웃 실패해도 로컬 로그아웃은 진행되므로 에러 무시
+      return ApiResult.failure(NetworkException.unexpected(message: e.toString()));
+    }
   }
 }
 

--- a/lib/features/auth/data/models/auth_token_result.dart
+++ b/lib/features/auth/data/models/auth_token_result.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'auth_token_result.g.dart';
+
+/// 인증 토큰 결과 모델
+///
+/// /auth/social 성공 응답의 result 필드
+@JsonSerializable()
+class AuthTokenResult {
+  const AuthTokenResult({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.firstLogin,
+  });
+
+  factory AuthTokenResult.fromJson(Map<String, dynamic> json) => _$AuthTokenResultFromJson(json);
+
+  final String accessToken;
+  final String refreshToken;
+  final bool firstLogin;
+
+  Map<String, dynamic> toJson() => _$AuthTokenResultToJson(this);
+}

--- a/lib/features/auth/service/auth_service.dart
+++ b/lib/features/auth/service/auth_service.dart
@@ -7,14 +7,22 @@ import 'package:flutter/foundation.dart';
 class AuthResult {
   const AuthResult({
     required this.isSuccess,
+    this.firstLogin,
     this.errorMessage,
   });
 
-  factory AuthResult.success() => const AuthResult(isSuccess: true);
+  factory AuthResult.success({required bool firstLogin}) => AuthResult(
+        isSuccess: true,
+        firstLogin: firstLogin,
+      );
 
-  factory AuthResult.failure(String message) => AuthResult(isSuccess: false, errorMessage: message);
+  factory AuthResult.failure(String message) => AuthResult(
+        isSuccess: false,
+        errorMessage: message,
+      );
 
   final bool isSuccess;
+  final bool? firstLogin;
   final String? errorMessage;
 }
 
@@ -54,15 +62,23 @@ class AuthService {
       );
 
       return serverResult.when(
-        success: (tokenResponse) async {
+        success: (apiResponse) async {
+          // isSuccess 체크
+          if (!apiResponse.isSuccess || apiResponse.result == null) {
+            debugPrint('서버 응답 실패: ${apiResponse.message}');
+            return AuthResult.failure(apiResponse.message);
+          }
+
+          var tokenResult = apiResponse.result!;
+
           // 3. 토큰 저장
           await _tokenStorage.saveTokens(
-            accessToken: tokenResponse.accessToken,
-            refreshToken: tokenResponse.refreshToken,
+            accessToken: tokenResult.accessToken,
+            refreshToken: tokenResult.refreshToken,
           );
 
-          debugPrint('서버 토큰 발급 및 저장 완료');
-          return AuthResult.success();
+          debugPrint('서버 토큰 발급 및 저장 완료, firstLogin: ${tokenResult.firstLogin}');
+          return AuthResult.success(firstLogin: tokenResult.firstLogin);
         },
         failure: (exception) {
           debugPrint('서버 토큰 발급 실패: ${exception.message}');
@@ -89,11 +105,15 @@ class AuthService {
 
   /// 로그아웃
   Future<void> logout() async {
-    try {
-      // 서버 로그아웃 (선택적)
-      await _authApi.logout();
-    } catch (e) {
-      debugPrint('서버 로그아웃 실패: $e');
+    var refreshToken = _tokenStorage.getRefreshToken();
+
+    // 서버 로그아웃 (실패해도 로컬 로그아웃은 진행)
+    if (refreshToken != null) {
+      var result = await _authApi.logout(refreshToken: refreshToken);
+      result.when(
+        success: (_) => debugPrint('서버 로그아웃 성공'),
+        failure: (e) => debugPrint('서버 로그아웃 실패: ${e.message}'),
+      );
     }
 
     // 카카오 로그아웃
@@ -113,12 +133,18 @@ class AuthService {
     var result = await _authApi.refreshToken(refreshToken: refreshToken);
 
     return result.when(
-      success: (tokenResponse) async {
+      success: (apiResponse) async {
+        if (!apiResponse.isSuccess || apiResponse.result == null) {
+          debugPrint('토큰 갱신 실패: ${apiResponse.message}');
+          return null;
+        }
+
+        var tokenResult = apiResponse.result!;
         await _tokenStorage.saveTokens(
-          accessToken: tokenResponse.accessToken,
-          refreshToken: tokenResponse.refreshToken,
+          accessToken: tokenResult.accessToken,
+          refreshToken: tokenResult.refreshToken,
         );
-        return tokenResponse.accessToken;
+        return tokenResult.accessToken;
       },
       failure: (exception) {
         debugPrint('토큰 갱신 실패: ${exception.message}');
@@ -132,13 +158,10 @@ class AuthService {
     return _tokenStorage.getAccessToken();
   }
 
-  /// 로그인 상태 확인
+  /// 로그인 상태 확인 (토큰 존재 여부)
+  ///
+  /// 토큰 만료 여부는 API 호출 시 서버 401 응답으로 판단
   bool isLoggedIn() {
     return _tokenStorage.hasToken();
-  }
-
-  /// 토큰 만료 여부 확인
-  bool isTokenExpired() {
-    return _tokenStorage.isTokenExpired();
   }
 }

--- a/lib/features/auth/service/token_storage_service.dart
+++ b/lib/features/auth/service/token_storage_service.dart
@@ -3,7 +3,8 @@ import 'package:flutter/foundation.dart';
 
 /// 토큰 저장소 서비스
 ///
-/// Access Token과 Refresh Token을 안전하게 저장/조회/삭제
+/// Access Token과 Refresh Token을 저장/조회/삭제
+/// 토큰 만료 여부는 서버 401 응답으로 판단 (로컬 만료 시간 체크 불필요)
 class TokenStorageService {
   TokenStorageService._internal();
 
@@ -12,12 +13,6 @@ class TokenStorageService {
   /// 싱글톤 인스턴스
   static TokenStorageService get instance => _instance;
 
-  /// Access Token 만료 시간: 15분
-  static const int _accessTokenExpiryMinutes = 15;
-
-  /// Refresh Token 만료 시간: 7일
-  static const int _refreshTokenExpiryDays = 7;
-
   final _prefs = Prefs();
 
   /// 토큰 일괄 저장
@@ -25,19 +20,9 @@ class TokenStorageService {
     required String accessToken,
     required String refreshToken,
   }) async {
-    var now = DateTime.now().millisecondsSinceEpoch;
-
-    // Access Token 저장 (15분 만료)
     await _prefs.setAccessToken(accessToken);
-    var accessExpiry = now + (_accessTokenExpiryMinutes * 60 * 1000);
-    await _prefs.setAccessTokenExpiry(accessExpiry);
-
-    // Refresh Token 저장 (7일 만료)
     await _prefs.setRefreshToken(refreshToken);
-    var refreshExpiry = now + (_refreshTokenExpiryDays * 24 * 60 * 60 * 1000);
-    await _prefs.setRefreshTokenExpiry(refreshExpiry);
-
-    debugPrint('토큰 저장 완료 (Access: 15분, Refresh: 7일)');
+    debugPrint('토큰 저장 완료');
   }
 
   /// Access Token 조회
@@ -56,39 +41,9 @@ class TokenStorageService {
     return accessToken != null && accessToken.isNotEmpty;
   }
 
-  /// Access Token 만료 여부 확인
-  bool isAccessTokenExpired() {
-    var expiry = _prefs.accessTokenExpiry;
-    if (expiry == null) return true;
-
-    var now = DateTime.now().millisecondsSinceEpoch;
-    // 만료 1분 전에 만료로 처리 (갱신 여유 시간)
-    return now >= (expiry - 60000);
-  }
-
-  /// Refresh Token 만료 여부 확인
-  bool isRefreshTokenExpired() {
-    var expiry = _prefs.refreshTokenExpiry;
-    if (expiry == null) return true;
-
-    var now = DateTime.now().millisecondsSinceEpoch;
-    return now >= expiry;
-  }
-
-  /// Access Token 만료 여부 (기존 메서드명 호환)
-  bool isTokenExpired() {
-    return isAccessTokenExpired();
-  }
-
   /// 모든 토큰 삭제
   Future<void> clearTokens() async {
     await _prefs.clearAuthData();
     debugPrint('모든 토큰 삭제 완료');
-  }
-
-  /// Access Token만 삭제
-  Future<void> clearAccessToken() async {
-    await _prefs.setAccessToken(null);
-    await _prefs.setAccessTokenExpiry(null);
   }
 }

--- a/lib/features/login/login_page.dart
+++ b/lib/features/login/login_page.dart
@@ -37,10 +37,16 @@ class _LoginPageState extends State<LoginPage> {
       if (!mounted) return;
 
       if (result.isSuccess) {
-        debugPrint('로그인 성공');
+        debugPrint('로그인 성공, firstLogin: ${result.firstLogin}');
 
-        // 메인 화면으로 이동
-        Routes.go(context, '/');
+        // firstLogin 분기 처리
+        if (result.firstLogin == true) {
+          // 신규 사용자: 온보딩 키워드 선택으로 이동
+          Routes.go(context, '/onboarding/keywords');
+        } else {
+          // 기존 사용자: 홈으로 이동
+          Routes.go(context, '/');
+        }
       } else {
         SnackBarUtils.showError(
           context,

--- a/lib/features/login/service/kakao_login_service.dart
+++ b/lib/features/login/service/kakao_login_service.dart
@@ -84,8 +84,6 @@ class KakaoLoginService {
       }
 
       debugPrint('카카오 로그인 성공');
-      debugPrint('accessToken: ${token.accessToken}');
-      debugPrint('idToken: ${token.idToken}');
 
       // OIDC ID Token 확인
       if (token.idToken == null) {

--- a/lib/features/my/view/my_view.dart
+++ b/lib/features/my/view/my_view.dart
@@ -1,3 +1,5 @@
+import 'package:arttrip/features/auth/service/auth_service.dart';
+import 'package:arttrip/routes/routes.dart';
 import 'package:flutter/material.dart';
 
 class MyView extends StatelessWidget {
@@ -5,10 +7,54 @@ class MyView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('마이페이지'),
+      ),
       body: Center(
-        child: Text('My'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('My'),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () => _handleLogout(context),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('로그아웃'),
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  Future<void> _handleLogout(BuildContext context) async {
+    var confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('로그아웃'),
+        content: const Text('정말 로그아웃 하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('로그아웃'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      await AuthService.instance.logout();
+      if (context.mounted) {
+        Routes.go(context, '/login');
+      }
+    }
   }
 }

--- a/lib/features/onboarding/data/keyword_api_service.dart
+++ b/lib/features/onboarding/data/keyword_api_service.dart
@@ -1,0 +1,43 @@
+import 'package:arttrip/core/network/models/api_response.dart';
+import 'package:arttrip/core/network/network.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword.dart';
+
+/// 키워드 관련 API 서비스
+class KeywordApiService extends BaseApiService {
+  KeywordApiService({super.client});
+
+  /// 모든 키워드 조회
+  Future<ApiResult<ApiResponse<List<Keyword>>>> getAllKeywords() {
+    return get<ApiResponse<List<Keyword>>>(
+      '/auth/allkeywords',
+      fromJson: (data) {
+        var json = data as Map<String, dynamic>;
+        return ApiResponse.fromJson(
+          json,
+          (obj) {
+            if (obj == null) return <Keyword>[];
+            var list = obj as List<dynamic>;
+            return list.map((e) => Keyword.fromJson(e as Map<String, dynamic>)).toList();
+          },
+        );
+      },
+    );
+  }
+
+  /// 키워드 저장
+  Future<ApiResult<ApiResponse<String>>> saveKeywords({
+    required List<int> keywordIds,
+  }) {
+    return post<ApiResponse<String>>(
+      '/auth/keywords',
+      data: {'keywordIds': keywordIds},
+      fromJson: (data) {
+        var json = data as Map<String, dynamic>;
+        return ApiResponse.fromJson(
+          json,
+          (obj) => obj as String? ?? '',
+        );
+      },
+    );
+  }
+}

--- a/lib/features/onboarding/data/keywords_repository.dart
+++ b/lib/features/onboarding/data/keywords_repository.dart
@@ -1,0 +1,41 @@
+import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/network/dio_client.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword.dart';
+import 'package:arttrip/shared/models/base_result_model.dart';
+
+abstract class KeywordsRepository {
+  Future<List<Keyword>?> fetchAllKeywords();
+  Future<bool> saveKeywords(List<int> keywordIds);
+}
+
+class KeywordsRepositoryImpl implements KeywordsRepository {
+  KeywordsRepositoryImpl(this._dio);
+  final DioClient _dio;
+
+  @override
+  Future<List<Keyword>?> fetchAllKeywords() async {
+    try {
+      var response = await _dio.get('/auth/allkeywords');
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      return model.result.map<Keyword>((e) => Keyword.fromJson(e)).toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchAllKeywords: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> saveKeywords(List<int> keywordIds) async {
+    try {
+      var response = await _dio.post(
+        '/auth/keywords',
+        data: {'keywordIds': keywordIds},
+      );
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      return model.isSuccess;
+    } catch (e) {
+      AppUtil.debugLog('saveKeywords: $e');
+    }
+    return false;
+  }
+}

--- a/lib/features/onboarding/data/keywords_repository_mock.dart
+++ b/lib/features/onboarding/data/keywords_repository_mock.dart
@@ -1,0 +1,32 @@
+import 'package:arttrip/features/onboarding/data/keywords_repository.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword.dart';
+
+class KeywordsRepositoryMockImpl implements KeywordsRepository {
+  KeywordsRepositoryMockImpl();
+
+  @override
+  Future<List<Keyword>?> fetchAllKeywords() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    return [
+      // GENRE
+      Keyword(keywordId: 1, name: '현대미술', type: 'GENRE'),
+      Keyword(keywordId: 2, name: '근대미술', type: 'GENRE'),
+      Keyword(keywordId: 3, name: '사진', type: 'GENRE'),
+      Keyword(keywordId: 4, name: '설치미술', type: 'GENRE'),
+      Keyword(keywordId: 5, name: '조각', type: 'GENRE'),
+      Keyword(keywordId: 6, name: '회화', type: 'GENRE'),
+      // STYLE
+      Keyword(keywordId: 7, name: '감성적인', type: 'STYLE'),
+      Keyword(keywordId: 8, name: '역동적인', type: 'STYLE'),
+      Keyword(keywordId: 9, name: '몽환적인', type: 'STYLE'),
+      Keyword(keywordId: 10, name: '고요한', type: 'STYLE'),
+      Keyword(keywordId: 11, name: '실험적인', type: 'STYLE'),
+    ];
+  }
+
+  @override
+  Future<bool> saveKeywords(List<int> keywordIds) async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    return true;
+  }
+}

--- a/lib/features/onboarding/data/models/keyword.dart
+++ b/lib/features/onboarding/data/models/keyword.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'keyword.freezed.dart';
+part 'keyword.g.dart';
+
+/// 키워드 모델
+///
+/// 전시 장르(GENRE) 또는 전시 스타일(STYLE)
+@freezed
+abstract class Keyword with _$Keyword {
+  const Keyword._();
+
+  factory Keyword({
+    required int keywordId,
+    required String name,
+    required String type, // "GENRE" | "STYLE"
+  }) = _Keyword;
+
+  factory Keyword.fromJson(Map<String, dynamic> json) => _$KeywordFromJson(json);
+
+  bool get isGenre => type == 'GENRE';
+  bool get isStyle => type == 'STYLE';
+}

--- a/lib/features/onboarding/view/keywords_page.dart
+++ b/lib/features/onboarding/view/keywords_page.dart
@@ -1,0 +1,205 @@
+import 'package:arttrip/features/onboarding/data/models/keyword.dart';
+import 'package:arttrip/features/onboarding/viewmodel/keywords_viewmodel.dart';
+import 'package:arttrip/features/onboarding/widgets/keyword_chip.dart';
+import 'package:arttrip/routes/routes.dart';
+import 'package:arttrip/shared/utils/snackbar_utils.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+/// 관심 키워드 선택 페이지
+///
+/// 신규 사용자(firstLogin: true)가 최초 로그인 시 이동하는 온보딩 화면
+class KeywordsPage extends StatefulWidget {
+  const KeywordsPage({super.key});
+
+  @override
+  State<KeywordsPage> createState() => _KeywordsPageState();
+}
+
+class _KeywordsPageState extends State<KeywordsPage> {
+  // 색상 상수
+  static const _primaryColor = Color(0xFF7859FF);
+  static const _textColor = Color(0xFF111111);
+  static const _requiredColor = Color(0xFFFF5255);
+  static const _disabledBgColor = Color(0xFFDBDBDB);
+  static const _disabledTextColor = Color(0xFFA5A5AF);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<KeywordsViewModel>().fetchKeywords();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var vm = context.watch<KeywordsViewModel>();
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: vm.isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Padding(
+                padding: EdgeInsets.symmetric(horizontal: 24.w),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildHeader(),
+                    _buildDivider(),
+                    Expanded(child: _buildContent(vm)),
+                    _buildSubmitButton(vm),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: EdgeInsets.only(top: 32.h, bottom: 16.h),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ArtTripText.pretendard().headline().color(_textColor).build().text('관심있는 키워드를\n골라주세요!'),
+          SizedBox(height: 8.h),
+          ArtTripText.pretendard().body01Regular().color(_textColor).build().text('한 가지 이상 선택이 가능해요.'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDivider() {
+    return const Divider(color: Color(0xFFDBDBDB), height: 1, thickness: 1);
+  }
+
+  Widget _buildContent(KeywordsViewModel vm) {
+    return SingleChildScrollView(
+      padding: EdgeInsets.symmetric(vertical: 24.h),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSection(
+            title: '좋아하는 전시 장르는 무엇인가요?',
+            keywords: vm.genres,
+            vm: vm,
+          ),
+          SizedBox(height: 32.h),
+          _buildSection(
+            title: '전시 스타일을 골라 주세요',
+            keywords: vm.styles,
+            vm: vm,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required List<Keyword> keywords,
+    required KeywordsViewModel vm,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: TextSpan(
+            children: [
+              TextSpan(
+                text: title,
+                style: TextStyle(
+                  fontFamily: 'Pretendard',
+                  fontSize: 16.sp,
+                  fontWeight: FontWeight.w700,
+                  color: _textColor,
+                ),
+              ),
+              TextSpan(
+                text: '*',
+                style: TextStyle(
+                  fontFamily: 'Pretendard',
+                  fontSize: 16.sp,
+                  fontWeight: FontWeight.w700,
+                  color: _requiredColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 24.h),
+        Wrap(
+          spacing: 8.w,
+          runSpacing: 12.h,
+          children: keywords.map((keyword) {
+            return KeywordChip(
+              label: keyword.name,
+              isSelected: vm.isSelected(keyword.keywordId),
+              onTap: () => vm.toggleKeyword(keyword.keywordId),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSubmitButton(KeywordsViewModel vm) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 16.h),
+      child: SizedBox(
+        width: double.infinity,
+        height: 52.h,
+        child: ElevatedButton(
+          onPressed: vm.canSubmit ? () => _handleSubmit(vm) : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: vm.canSubmit ? _primaryColor : _disabledBgColor,
+            foregroundColor: vm.canSubmit ? Colors.white : _disabledTextColor,
+            disabledBackgroundColor: _disabledBgColor,
+            disabledForegroundColor: _disabledTextColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10.r),
+            ),
+            elevation: 0,
+          ),
+          child: vm.isSaving
+              ? SizedBox(
+                  width: 24.w,
+                  height: 24.h,
+                  child: const CircularProgressIndicator(
+                    color: Colors.white,
+                    strokeWidth: 2,
+                  ),
+                )
+              : Text(
+                  '완료',
+                  style: TextStyle(
+                    fontFamily: 'Pretendard',
+                    fontSize: 16.sp,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+
+  // ===== Methods =====
+
+  Future<void> _handleSubmit(KeywordsViewModel vm) async {
+    var success = await vm.saveKeywords();
+
+    if (success) {
+      if (mounted) {
+        Routes.go(context, '/');
+      }
+    } else {
+      if (mounted) {
+        SnackBarUtils.showError(context, message: '키워드 저장에 실패했습니다');
+      }
+    }
+  }
+}

--- a/lib/features/onboarding/viewmodel/keywords_viewmodel.dart
+++ b/lib/features/onboarding/viewmodel/keywords_viewmodel.dart
@@ -1,0 +1,69 @@
+import 'package:arttrip/features/onboarding/data/keywords_repository.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword.dart';
+import 'package:flutter/material.dart';
+
+class KeywordsViewModel with ChangeNotifier {
+  KeywordsViewModel(this.repository);
+  final KeywordsRepository repository;
+
+  List<Keyword> _genres = [];
+  List<Keyword> _styles = [];
+  final Set<int> _selectedKeywordIds = {};
+
+  bool _isLoading = true;
+  bool _isSaving = false;
+  String? _errorMessage;
+
+  List<Keyword> get genres => _genres;
+  List<Keyword> get styles => _styles;
+  Set<int> get selectedKeywordIds => _selectedKeywordIds;
+  bool get isLoading => _isLoading;
+  bool get isSaving => _isSaving;
+  String? get errorMessage => _errorMessage;
+  bool get canSubmit => _selectedKeywordIds.isNotEmpty;
+
+  Future<void> fetchKeywords() async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    var keywords = await repository.fetchAllKeywords();
+
+    if (keywords != null) {
+      _genres = keywords.where((k) => k.isGenre).toList();
+      _styles = keywords.where((k) => k.isStyle).toList();
+    } else {
+      _errorMessage = '키워드를 불러오는데 실패했습니다';
+    }
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  void toggleKeyword(int keywordId) {
+    if (_selectedKeywordIds.contains(keywordId)) {
+      _selectedKeywordIds.remove(keywordId);
+    } else {
+      _selectedKeywordIds.add(keywordId);
+    }
+    notifyListeners();
+  }
+
+  bool isSelected(int keywordId) {
+    return _selectedKeywordIds.contains(keywordId);
+  }
+
+  Future<bool> saveKeywords() async {
+    if (!canSubmit || _isSaving) return false;
+
+    _isSaving = true;
+    notifyListeners();
+
+    var success = await repository.saveKeywords(_selectedKeywordIds.toList());
+
+    _isSaving = false;
+    notifyListeners();
+
+    return success;
+  }
+}

--- a/lib/features/onboarding/widgets/keyword_chip.dart
+++ b/lib/features/onboarding/widgets/keyword_chip.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 키워드 선택 칩 위젯
+class KeywordChip extends StatelessWidget {
+  const KeywordChip({
+    super.key,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  // 색상 상수
+  static const _selectedBgColor = Color(0xFF7859FF);
+  static const _unselectedBorderColor = Color(0xFFDBDBDB);
+  static const _textColor = Color(0xFF111111);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 100.w,
+        height: 40.h,
+        decoration: BoxDecoration(
+          color: isSelected ? _selectedBgColor : Colors.transparent,
+          borderRadius: BorderRadius.circular(40.r),
+          border: isSelected ? null : Border.all(color: _unselectedBorderColor, width: 1),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: 'Pretendard',
+            fontSize: 14.sp,
+            fontWeight: isSelected ? FontWeight.w700 : FontWeight.w300,
+            color: isSelected ? Colors.white : _textColor,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/splash/view/splash_view.dart
+++ b/lib/features/splash/view/splash_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 /// 스플래시 화면
 ///
 /// 앱 시작 시 인증 상태를 확인하고 적절한 화면으로 이동
+/// 토큰 만료 여부는 API 호출 시 서버 401 응답으로 판단
 class SplashView extends StatefulWidget {
   const SplashView({super.key});
 
@@ -30,27 +31,10 @@ class _SplashViewState extends State<SplashView> {
 
     var authService = AuthService.instance;
 
-    // 토큰 존재 여부 확인
-    if (!authService.isLoggedIn()) {
-      _navigateToLogin();
-      return;
-    }
-
-    // 토큰 만료 여부 확인
-    if (!authService.isTokenExpired()) {
-      // 토큰이 유효하면 홈으로
-      _navigateToHome();
-      return;
-    }
-
-    // 토큰이 만료되었으면 갱신 시도
-    var newToken = await authService.refreshToken();
-
-    if (newToken != null) {
-      // 갱신 성공하면 홈으로
+    // 토큰 존재 여부만 확인 (만료 여부는 API 호출 시 서버에서 판단)
+    if (authService.isLoggedIn()) {
       _navigateToHome();
     } else {
-      // 갱신 실패하면 로그인으로
       _navigateToLogin();
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,10 @@ void main() async {
     authInterceptor: AuthInterceptor(
       tokenProvider: () async => TokenStorageService.instance.getAccessToken(),
       onTokenRefresh: () => AuthService.instance.refreshToken(),
-      onTokenExpired: () => AuthService.instance.logout(),
+      onTokenExpired: () async {
+        await AuthService.instance.logout();
+        appRouter.go('/login');
+      },
     ),
   );
 

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:arttrip/features/login/login_page.dart';
+import 'package:arttrip/features/onboarding/view/keywords_page.dart';
 import 'package:arttrip/features/splash/view/splash_view.dart';
 import 'package:arttrip/routes/main_shell_route.dart';
 import 'package:arttrip/routes/route_builder.dart';
@@ -31,6 +32,14 @@ final appRouter = GoRouter(
       path: '/login',
       pageBuilder: (context, state) {
         return buildPage(context, state, child: const LoginPage());
+      },
+    ),
+
+    // 온보딩 - 관심 키워드 선택
+    GoRoute(
+      path: '/onboarding/keywords',
+      pageBuilder: (context, state) {
+        return buildPage(context, state, child: const KeywordsPage());
       },
     ),
   ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,22 +349,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  freezed:
-    dependency: "direct dev"
-    description:
-      name: freezed
-      sha256: "2d399f823b8849663744d2a9ddcce01c49268fb4170d0442a655bf6a2f47be22"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
-  freezed_annotation:
-    dependency: "direct main"
-    description:
-      name: freezed_annotation
-      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -573,14 +557,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   nm:
     dependency: transitive
     description:
@@ -693,14 +669,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:


### PR DESCRIPTION
### 인증 시스템
- 401 에러 코드 기반 토큰 자동 갱신 (`JWT401-EXPIRED_ACCESS`만 갱신, 나머지는 로그아웃)
- 토큰 만료 관리를 서버 응답 기반으로 변경 (로컬 만료 시간 제거)
- `firstLogin` 분기 처리 추가 (신규 사용자 → 온보딩, 기존 사용자 → 홈)
- 마이페이지 로그아웃 기능 추가

### 온보딩
- 키워드 선택 페이지 구현 (장르/스타일)
- Keyword 모델, Repository, ViewModel 추가 (freezed + Provider 패턴)

### 네트워크
- API 로깅 한 줄로 간소화
- 인증 API 재시도 제외 처리