### PR TITLE
refactor: mock데이터 의존성 주입 변경, 오늘의 추천전시 API 연동, 국내/해외 값 변경

### DIFF
--- a/lib/core/app_consts.dart
+++ b/lib/core/app_consts.dart
@@ -2,4 +2,5 @@ class AppConsts {
   const AppConsts._();
 
   static const bool useMock = true; // Force using dummy data
+  static const int mockLoadingDelayMillis = 500; // Dummy data loading delay in milliseconds
 }

--- a/lib/core/config/provider_config.dart
+++ b/lib/core/config/provider_config.dart
@@ -3,6 +3,7 @@ import 'package:arttrip/core/network/network.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/features/home/home_repository_mock.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/features/home/hybrid_home_repository.dart';
 import 'package:arttrip/features/onboarding/data/keywords_repository.dart';
 import 'package:arttrip/features/onboarding/data/keywords_repository_mock.dart';
 import 'package:arttrip/features/onboarding/viewmodel/keywords_viewmodel.dart';
@@ -10,9 +11,11 @@ import 'package:provider/provider.dart';
 
 final List<ChangeNotifierProvider> getProviders = [
   ChangeNotifierProvider<HomeViewModel>(
-    create: (_) => HomeViewModel(AppConsts.useMock ? HomeRepositoryMockImpl() : HomeRepositoryImpl(DioClient.instance)),
+    create: (_) => HomeViewModel(
+        HybridHomeRepository(mock: HomeRepositoryMockImpl(), api: HomeRepositoryImpl(DioClient.instance))),
   ),
   ChangeNotifierProvider<KeywordsViewModel>(
-    create: (_) => KeywordsViewModel(AppConsts.useMock ? KeywordsRepositoryMockImpl() : KeywordsRepositoryImpl(DioClient.instance)),
+    create: (_) => KeywordsViewModel(
+        AppConsts.useMock ? KeywordsRepositoryMockImpl() : KeywordsRepositoryImpl(DioClient.instance)),
   ),
 ];

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,9 +1,11 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/features/home/views/international_domestic_tab_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -35,12 +37,11 @@ class _HomePageState extends State<HomePage> {
                 onTap: () {},
                 child: SvgPicture.asset(AppAssets.icNotification, width: 24.w, height: 24.w),
               ),
+              GestureDetector(onTap: () {}, child: SvgPicture.asset(AppAssets.icCalendar, width: 24.w, height: 24.w)),
               GestureDetector(
-                onTap: () {},
-                child: SvgPicture.asset(AppAssets.icCalendar, width: 24.w, height: 24.w),
-              ),
-              GestureDetector(
-                onTap: () {},
+                onTap: () {
+                  Provider.of<HomeViewModel>(context, listen: false).fetchTodayExhibitRecommendations(country: '전체');
+                },
                 child: SvgPicture.asset(AppAssets.icSearch, width: 24.w, height: 24.w),
               ),
             ],
@@ -51,9 +52,7 @@ class _HomePageState extends State<HomePage> {
       body: CustomScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
         controller: _scrollController,
-        slivers: [
-          const InternationalDomesticTabView(),
-        ],
+        slivers: [const InternationalDomesticTabView()],
       ),
     );
   }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -1,10 +1,16 @@
 import 'package:arttrip/core/app_utils.dart';
 import 'package:arttrip/core/network/dio_client.dart';
 import 'package:arttrip/shared/models/base_result_model.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
 
 abstract class HomeRepository {
   Future<List<String>?> fetchOverseasCountries();
   Future<List<String>?> fetchDomesticRegions();
+  Future<List<ExhibitModel>?> fetchTodayExhibitRecommendations({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  });
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -17,9 +23,7 @@ class HomeRepositoryImpl implements HomeRepository {
       var response = await _dio.get('/exhibit/overseas');
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog(
-          'fetchOverseasCountries type inconsistency: ${model.result.runtimeType}',
-        );
+        AppUtil.debugLog('fetchOverseasCountries type inconsistency: ${model.result.runtimeType}');
         return null;
       }
 
@@ -36,15 +40,35 @@ class HomeRepositoryImpl implements HomeRepository {
       var response = await _dio.get('/exhibit/domestic');
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog(
-          'fetchDomesticRegions type inconsistency: ${model.result.runtimeType}',
-        );
+        AppUtil.debugLog('fetchDomesticRegions type inconsistency: ${model.result.runtimeType}');
         return null;
       }
 
       return model.result.map<String>((e) => e.toString()).toList();
     } catch (e) {
       AppUtil.debugLog('fetchDomesticRegions: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchTodayExhibitRecommendations({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) async {
+    try {
+      var body =
+          !isDomestic ? {'isDomestic': isDomestic, 'country': country} : {'isDomestic': isDomestic, 'region': region};
+      var response = await _dio.post('/home/recommend/today', data: body);
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog('fetchTodayExhibitRecommendations type inconsistency: ${model.result.runtimeType}');
+        return null;
+      }
+      return model.result.map<ExhibitModel>((e) => ExhibitModel.fromJson(e)).toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchTodayExhibitRecommendations: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -1,32 +1,48 @@
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/features/home/home_repository.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
 
 class HomeRepositoryMockImpl implements HomeRepository {
   HomeRepositoryMockImpl();
 
   @override
   Future<List<String>?> fetchOverseasCountries() async {
-    await Future.delayed(const Duration(milliseconds: 100)); // 실제 딜레이 흉내
-    return [
-      '프랑스',
-      '오스트리아',
-      '중국',
-      '일본',
-      '독일',
-      '대한민국',
-    ];
+    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis)); // 실제 딜레이 흉내
+    return ['프랑스', '오스트리아', '중국', '일본', '독일', '대한민국'];
   }
 
   @override
   Future<List<String>?> fetchDomesticRegions() async {
-    await Future.delayed(const Duration(milliseconds: 100));
+    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
+    return ['서울', '경기', '충청', '강원', '전라', '경상', '제주'];
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchTodayExhibitRecommendations({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
     return [
-      '서울',
-      '경기',
-      '충청',
-      '강원',
-      '전라',
-      '경상',
-      '제주',
+      ExhibitModel(
+          exhibitId: 7,
+          title: 'Koki Tanaka: Provisional Community',
+          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+          status: 'ONGOING',
+          exhibitPeriod: '2025-09-27 09:00:00.000000 ~ 2026-01-05 08:59:59.000000'),
+      ExhibitModel(
+          exhibitId: 8,
+          title: 'In Sight! Lovis Corinth',
+          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+          status: 'UPCOMING',
+          exhibitPeriod: '2025-07-18 09:00:00.000000 ~ 2026-01-26 08:59:59.000000'),
+      ExhibitModel(
+          exhibitId: 1,
+          title: 'Matisse – Soulages',
+          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+          status: 'ONGOING',
+          exhibitPeriod: '2025-10-18 09:00:00.000000 ~ 2026-03-09 08:59:59.000000'),
     ];
   }
 }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,11 +1,12 @@
 import 'package:arttrip/features/home/home_repository.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:flutter/material.dart';
 
 class HomeViewModel with ChangeNotifier {
   HomeViewModel(this.repository);
   final HomeRepository repository;
 
-  bool _isDomestic = true;
+  bool _isDomestic = false;
   String? _selectedRegion;
 
   bool get isDomestic => _isDomestic;
@@ -31,5 +32,16 @@ class HomeViewModel with ChangeNotifier {
 
   Future<List<String>?> fetchDomesticRegions() {
     return repository.fetchDomesticRegions();
+  }
+
+  Future<List<ExhibitModel>?> fetchTodayExhibitRecommendations({
+    String? country,
+    String? region,
+  }) {
+    return repository.fetchTodayExhibitRecommendations(
+      isDomestic: _isDomestic,
+      country: country,
+      region: region,
+    );
   }
 }

--- a/lib/features/home/hybrid_home_repository.dart
+++ b/lib/features/home/hybrid_home_repository.dart
@@ -1,0 +1,38 @@
+import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/features/home/home_repository.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
+
+class HybridHomeRepository implements HomeRepository {
+  HybridHomeRepository({required this.mock, required this.api});
+
+  final HomeRepository mock;
+  final HomeRepositoryImpl api;
+
+  @override
+  Future<List<String>?> fetchOverseasCountries() {
+    if (AppConsts.useMock) {
+      return mock.fetchOverseasCountries();
+    }
+    return api.fetchOverseasCountries();
+  }
+
+  @override
+  Future<List<String>?> fetchDomesticRegions() {
+    if (AppConsts.useMock) {
+      return mock.fetchDomesticRegions();
+    }
+    return api.fetchDomesticRegions();
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchTodayExhibitRecommendations({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) {
+    if (AppConsts.useMock) {
+      return mock.fetchTodayExhibitRecommendations(isDomestic: isDomestic);
+    }
+    return api.fetchTodayExhibitRecommendations(isDomestic: isDomestic, country: country, region: region);
+  }
+}

--- a/lib/features/home/views/international_domestic_tab_view.dart
+++ b/lib/features/home/views/international_domestic_tab_view.dart
@@ -36,70 +36,72 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
     _selectedRegionIndex.value = index;
     Provider.of<HomeViewModel>(context, listen: false).updateSelectedRegion(region ?? allItem!);
     if (_itemKeys![index].currentContext != null) {
-      Scrollable.ensureVisible(_itemKeys![index].currentContext!,
-          alignment: 0.5, duration: const Duration(milliseconds: 500));
+      Scrollable.ensureVisible(
+        _itemKeys![index].currentContext!,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 500),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return SliverList(
-      delegate: SliverChildBuilderDelegate(
-        (context, index) {
-          switch (index) {
-            /// tabbar
-            case 0:
-              return _buildExhibitionTabBar();
+      delegate: SliverChildBuilderDelegate((context, index) {
+        switch (index) {
+          /// tabbar
+          case 0:
+            return _buildExhibitionTabBar();
 
-            /// countries
-            case 1:
-              return SizedBox(
-                height: 64.h,
-                child: ValueListenableBuilder(
-                    valueListenable: _regionsFuture,
-                    builder: (context, regionsFuture, _) {
-                      var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-                      return FutureWhen(
-                        future: regionsFuture ?? homeViewModel.fetchOverseasCountries(),
-                        data: (data) {
-                          if (data?.isEmpty ?? true) return const SizedBox.shrink();
+          /// countries
+          case 1:
+            return SizedBox(
+              height: 64.h,
+              child: ValueListenableBuilder(
+                valueListenable: _regionsFuture,
+                builder: (context, regionsFuture, _) {
+                  var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
+                  return FutureWhen(
+                    future: regionsFuture ?? homeViewModel.fetchOverseasCountries(),
+                    data: (data) {
+                      if (data?.isEmpty ?? true) return const SizedBox.shrink();
 
-                          _selectedRegionIndex.value = 0; // 데이터 호출이 빠를 수 있어서 초기화 추가
-                          var itemCount = homeViewModel.isDomestic ? data!.length + 1 : data!.length;
-                          _itemKeys = List.generate(itemCount, (_) => GlobalKey());
+                      _selectedRegionIndex.value = 0; // 데이터 호출이 빠를 수 있어서 초기화 추가
+                      var itemCount = !homeViewModel.isDomestic ? data!.length + 1 : data!.length;
+                      _itemKeys = List.generate(itemCount, (_) => GlobalKey());
 
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
-                            _updateSelectedRegionIndex(0, homeViewModel.isDomestic ? allItem! : data[0]);
-                          });
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        _updateSelectedRegionIndex(0, !homeViewModel.isDomestic ? allItem! : data[0]);
+                      });
 
-                          return ListView.separated(
-                            shrinkWrap: true,
-                            itemCount: itemCount,
-                            scrollDirection: Axis.horizontal,
-                            padding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 24.w),
-                            separatorBuilder: (context, index) => SizedBox(width: 8.w),
-                            itemBuilder: (context, index) {
-                              return _buildRegionItem(
-                                  _itemKeys![index],
-                                  index,
-                                  homeViewModel.isDomestic
-                                      ? index == 0
-                                          ? null
-                                          : data[index - 1]
-                                      : data[index]);
-                            },
+                      return ListView.separated(
+                        shrinkWrap: true,
+                        itemCount: itemCount,
+                        scrollDirection: Axis.horizontal,
+                        padding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 24.w),
+                        separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                        itemBuilder: (context, index) {
+                          return _buildRegionItem(
+                            _itemKeys![index],
+                            index,
+                            !homeViewModel.isDomestic
+                                ? index == 0
+                                    ? null
+                                    : data[index - 1]
+                                : data[index],
                           );
                         },
                       );
-                    }),
-              );
+                    },
+                  );
+                },
+              ),
+            );
 
-            default:
-              return const SizedBox.shrink();
-          }
-        },
-        childCount: 2,
-      ),
+          default:
+            return const SizedBox.shrink();
+        }
+      }, childCount: 2),
     );
   }
 
@@ -120,13 +122,10 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
         indicatorSize: TabBarIndicatorSize.label,
         tabAlignment: TabAlignment.start,
         isScrollable: true,
-        tabs: [
-          Tab(text: context.l10n.internationalExhibition),
-          Tab(text: context.l10n.domesticExhibition),
-        ],
+        tabs: [Tab(text: context.l10n.internationalExhibition), Tab(text: context.l10n.domesticExhibition)],
         onTap: (index) {
           var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-          homeViewModel.isDomestic = index == 0 ? true : false;
+          homeViewModel.isDomestic = index == 0 ? false : true;
           if (index == 0) {
             _regionsFuture.value = homeViewModel.fetchOverseasCountries();
           } else {
@@ -143,25 +142,26 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
         if (_selectedRegionIndex.value != index) _updateSelectedRegionIndex(index, index == 0 ? allItem! : country!);
       },
       child: ValueListenableBuilder(
-          valueListenable: _selectedRegionIndex,
-          builder: (context, selectedRegionIndex, _) {
-            var isSelected = index == selectedRegionIndex;
-            return Container(
-              key: key,
-              padding: EdgeInsets.symmetric(horizontal: 20.w),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(100),
-                color: isSelected ? AppColors.primary300 : AppColors.gray0,
-                border: Border.all(color: isSelected ? AppColors.primary300 : AppColors.gray100, width: 1.w),
-              ),
-              child: ArtTripText.pretendard()
-                  .body01Bold()
-                  .color(isSelected ? AppColors.textWhite : AppColors.textPrimary)
-                  .build()
-                  .text(country ?? context.l10n.allItems),
-            );
-          }),
+        valueListenable: _selectedRegionIndex,
+        builder: (context, selectedRegionIndex, _) {
+          var isSelected = index == selectedRegionIndex;
+          return Container(
+            key: key,
+            padding: EdgeInsets.symmetric(horizontal: 20.w),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(100),
+              color: isSelected ? AppColors.primary300 : AppColors.gray0,
+              border: Border.all(color: isSelected ? AppColors.primary300 : AppColors.gray100, width: 1.w),
+            ),
+            child: ArtTripText.pretendard()
+                .body01Bold()
+                .color(isSelected ? AppColors.textWhite : AppColors.textPrimary)
+                .build()
+                .text(country ?? context.l10n.allItems),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/shared/models/exhibit_model.dart
+++ b/lib/shared/models/exhibit_model.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'exhibit_model.freezed.dart';
+part 'exhibit_model.g.dart';
+
+@freezed
+abstract class ExhibitModel with _$ExhibitModel {
+  const ExhibitModel._();
+
+  factory ExhibitModel({
+    @JsonKey(name: 'exhibit_id') int? exhibitId,
+    String? title,
+    String? posterUrl,
+    String? status,
+    String? exhibitPeriod,
+  }) = _ExhibitModel;
+
+  factory ExhibitModel.fromJson(Map<String, dynamic> json) => _$ExhibitModelFromJson(json);
+}


### PR DESCRIPTION
## Summary
- mock 데이터 의존성 주입 변경
전체 더미 데이터 설정 에서 부분 비동기 메서드 더미 데이터 설정으로 변경하였습니다.
기존의 방식은 AppConsts.useMock = false 일 때, 부분적으로가 아닌, 모든 API 호출로 변경되어
더미 데이터를 사용하는 의미와 달랐습니다.
변경된 방법으로, hybridRepository에서 각 메서드별로 useMock을 체크하도록 하여 
부분 API 호출이 가능하도록 적용하였습니다.

- 오늘의 추천 전시 API 연동
- mock 데이터 로딩 시간 AppConsts.mockLoadingDelayMillis 추가
- home_viewmodel.dart _isDomestic = false 일때 해외 값으로 수정

## Usage
- 의존성 주입 변경
```dart
class HybridHomeRepository implements HomeRepository {
  HybridHomeRepository({required this.mock, required this.api});

  final HomeRepository mock;
  final HomeRepositoryImpl api;

  @override
  Future<List<String>?> fetchOverseasCountries() {
    if (AppConsts.useMock) {
      return mock.fetchOverseasCountries();
    }
    return api.fetchOverseasCountries();
  }
}
```

```dart
final List<ChangeNotifierProvider> getProviders = [
  ChangeNotifierProvider<HomeViewModel>(
    create: (_) => HomeViewModel(
        HybridHomeRepository(mock: HomeRepositoryMockImpl(), api: HomeRepositoryImpl(DioClient.instance))),
  ),
];
```