### PR TITLE
feat: 지역별 전시 목록 ui 추가, 단 이미지 변경 필요

### DIFF
--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -3,6 +3,7 @@ import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/features/home/views/international_domestic_tab_view.dart';
+import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -35,7 +36,8 @@ class _HomePageState extends State<HomePage> {
       backgroundColor: AppColors.gray0,
       appBar: AppBar(
         toolbarHeight: 52.h,
-        backgroundColor: Colors.white,
+        backgroundColor: AppColors.gray0,
+        surfaceTintColor: AppColors.gray0,
         leadingWidth: 88.w + 24.w,
         leading: Padding(
           padding: EdgeInsets.only(left: 24.w),
@@ -65,6 +67,12 @@ class _HomePageState extends State<HomePage> {
         slivers: [
           const InternationalDomesticTabView(),
           const TodayExhibitRecommendationView(),
+          Selector<HomeViewModel, bool>(
+              selector: (_, vm) => vm.isDomestic,
+              builder: (context, isDomestic, _) {
+                return isDomestic ? const RegionalExhibitionView() : const SliverToBoxAdapter(child: SizedBox.shrink());
+              }),
+              
           SliverToBoxAdapter(child: SizedBox(height: 24.h)),
         ],
       ),

--- a/lib/features/home/views/regional_exhibition_view.dart
+++ b/lib/features/home/views/regional_exhibition_view.dart
@@ -1,0 +1,73 @@
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+class RegionalExhibitionView extends StatefulWidget {
+  const RegionalExhibitionView({super.key});
+
+  @override
+  State<RegionalExhibitionView> createState() => _RegionalExhibitionViewState();
+}
+
+class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: EdgeInsetsGeometry.only(top: 32.h),
+      sliver: SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) {
+            switch (index) {
+              case 0:
+                return Padding(
+                  padding: EdgeInsets.only(left: 24.w, right: 24.w, bottom: 12.h),
+                  child: ArtTripText.pretendard().title01Bold().build().text(context.l10n.regionalExhibition),
+                );
+              case 1:
+                return Selector<HomeViewModel, AsyncState<List<String>>>(
+                  selector: (_, vm) => vm.locations,
+                  builder: (context, state, _) {
+                    return AsyncView(
+                      state: state,
+                      onData: (data) {
+                        return SizedBox(
+                          height: 90.h,
+                          child: ListView.separated(
+                            shrinkWrap: true,
+                            scrollDirection: Axis.horizontal,
+                            itemCount: data.length,
+                            padding: EdgeInsets.symmetric(horizontal: 24.w),
+                            separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                            itemBuilder: (context, index) {
+                              var item = data[index];
+                              return Column(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  CircleAvatar(
+                                    radius: 32.w,
+                                    backgroundColor: Colors.black,
+                                  ),
+                                  ArtTripText.pretendard().body02Bold().build().text(item),
+                                ],
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    );
+                  },
+                );
+              default:
+                return const SizedBox.shrink();
+            }
+          },
+          childCount: 2,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -17,5 +17,6 @@
   },
   "domesticExhibition": "국내전시",
   "internationalExhibition": "해외전시",
-  "allItems": "전체"
+  "allItems": "전체",
+  "regionalExhibition": "지역별 전시"
 }


### PR DESCRIPTION
## Summary
- 홈화면 지역별 전시 영역의 지역 목록 UI 추가
그러나 지역 이미지 컬럼이 추가 되어있지 않아, 차주에 수정이 필요합니다.

## Demo
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/93f6654f-e66d-487d-9231-01d01633e31e" />