### PR TITLE
feat: 장르별 랜덤 전시 목록 API연동, UI 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 {
   // Dart UI Guides.
   "dart.previewFlutterUiGuides": true,
-  "dart.lineLength": 120,
+  "dart.lineLength": 80,
   "editor.codeActionsOnSave": {
     "source.organizeImports": "always",
     "quickfix.add.required": "always",

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -56,6 +56,6 @@ analyzer:
     todo: ignore
 
 formatter:
-  page_width: 120
+  page_width: 80
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/assets/svg/ic_no_arrow_right.svg
+++ b/assets/svg/ic_no_arrow_right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 18L14.2929 12.7071C14.6834 12.3166 14.6834 11.6834 14.2929 11.2929L9 6" stroke="#111111" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/core/app_assets.dart
+++ b/lib/core/app_assets.dart
@@ -14,7 +14,9 @@ class AppAssets {
   static const String icCalendar = 'assets/svg/ic_calendar.svg';
   static const String icSearch = 'assets/svg/ic_search.svg';
   static String icLikeCircle({required bool isLiked}) =>
-      isLiked ? 'assets/svg/ic_like_circle_selected.svg' : 'assets/svg/ic_like_circle_default.svg';
+      isLiked
+          ? 'assets/svg/ic_like_circle_selected.svg'
+          : 'assets/svg/ic_like_circle_default.svg';
   static const String icNoArrowRight = 'assets/svg/ic_no_arrow_right.svg';
 
   // Logo

--- a/lib/core/app_assets.dart
+++ b/lib/core/app_assets.dart
@@ -15,6 +15,7 @@ class AppAssets {
   static const String icSearch = 'assets/svg/ic_search.svg';
   static String icLikeCircle({required bool isLiked}) =>
       isLiked ? 'assets/svg/ic_like_circle_selected.svg' : 'assets/svg/ic_like_circle_default.svg';
+  static const String icNoArrowRight = 'assets/svg/ic_no_arrow_right.svg';
 
   // Logo
   static const String icLogoWhite = 'assets/svg/ic_logo_white.svg';

--- a/lib/core/app_consts.dart
+++ b/lib/core/app_consts.dart
@@ -2,9 +2,12 @@ class AppConsts {
   const AppConsts._();
 
   static const bool useMock = true; // Force using dummy data
-  static const int mockLoadingDelayMillis =
+  static const int mockLoadingDelayMs =
       500; // Dummy data loading delay in milliseconds
 
   static const shimmerDurationMs = 1200;
   static const shimmerIntervalMs = 400;
+
+  static const weekDaysKo = ['일', '월', '화', '수', '목', '금', '토'];
+  static const weekDaysEn = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 }

--- a/lib/core/app_consts.dart
+++ b/lib/core/app_consts.dart
@@ -2,5 +2,9 @@ class AppConsts {
   const AppConsts._();
 
   static const bool useMock = true; // Force using dummy data
-  static const int mockLoadingDelayMillis = 500; // Dummy data loading delay in milliseconds
+  static const int mockLoadingDelayMillis =
+      500; // Dummy data loading delay in milliseconds
+
+  static const shimmerDurationMs = 1200;
+  static const shimmerIntervalMs = 400;
 }

--- a/lib/core/app_urls.dart
+++ b/lib/core/app_urls.dart
@@ -1,0 +1,6 @@
+class AppUrls {
+  const AppUrls._();
+
+  static const posterUrlMock =
+      'https://velog.velcdn.com/images/hodu_angel/post/f95b3407-6af6-4bf1-8e93-d859b376f175/image.png';
+}

--- a/lib/core/app_utils.dart
+++ b/lib/core/app_utils.dart
@@ -1,3 +1,6 @@
+import 'dart:ui';
+
+import 'package:arttrip/core/app_consts.dart';
 import 'package:flutter/foundation.dart';
 
 class AppUtil {
@@ -5,5 +8,30 @@ class AppUtil {
 
   static void debugLog(str) {
     if (kDebugMode) print('AppLog : $str');
+  }
+
+  /// 이번주의 각 DateTime 리스트
+  static List<DateTime> getCurrentWeek(DateTime focusedDay) {
+    // 일요일 시작
+    var sunday = focusedDay.subtract(Duration(days: focusedDay.weekday % 7));
+    return List.generate(7, (index) => sunday.add(Duration(days: index)));
+  }
+
+  /// 주간 요일
+  static String weekdayLabel({required DateTime date, required Locale locale}) {
+    var isKorean = locale.languageCode == 'ko';
+    var labels = isKorean ? AppConsts.weekDaysKo : AppConsts.weekDaysEn;
+
+    // DateTime.weekday: Mon=1 ... Sun=7
+    return labels[date.weekday % 7];
+  }
+
+  /// '2025-12-25' 포맷 반환
+  static String formatDateYMD(DateTime date) {
+    var year = date.year.toString().padLeft(4, '0');
+    var month = date.month.toString().padLeft(2, '0');
+    var day = date.day.toString().padLeft(2, '0');
+
+    return '$year-$month-$day';
   }
 }

--- a/lib/core/enum.dart
+++ b/lib/core/enum.dart
@@ -6,3 +6,13 @@ enum FontFamilyType {
   const FontFamilyType(this.fontName);
   final String fontName;
 }
+
+enum ExhibitionStatus {
+  upcoming('UPCOMING'), // 예정된 전시
+  onGoing('ONGOING'), // 진행 중인 전시
+  endingSoon('ENDING_SOON'), // 마감 임박(3일전부터)
+  finished('FINISHED'); // 종료된 전시
+
+  const ExhibitionStatus(this.status);
+  final String status;
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -2,6 +2,7 @@ import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/features/home/views/genre_exhibition_view.dart';
 import 'package:arttrip/features/home/views/international_domestic_tab_view.dart';
 import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
@@ -72,7 +73,7 @@ class _HomePageState extends State<HomePage> {
               builder: (context, isDomestic, _) {
                 return isDomestic ? const RegionalExhibitionView() : const SliverToBoxAdapter(child: SizedBox.shrink());
               }),
-              
+          const GenreExhibitionView(),
           SliverToBoxAdapter(child: SizedBox(height: 24.h)),
         ],
       ),

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -4,8 +4,10 @@ import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/features/home/views/genre_exhibition_view.dart';
 import 'package:arttrip/features/home/views/international_domestic_tab_view.dart';
+import 'package:arttrip/features/home/views/personalized_exhibition_view.dart';
 import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -18,12 +20,14 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   final ScrollController _scrollController = ScrollController();
+  late TabController _tabController;
 
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
       homeViewModel.selectedLocation = context.l10n.allItems;
@@ -35,47 +39,125 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.gray0,
-      appBar: AppBar(
-        toolbarHeight: 52.h,
-        backgroundColor: AppColors.gray0,
-        surfaceTintColor: AppColors.gray0,
-        leadingWidth: 88.w + 24.w,
-        leading: Padding(
-          padding: EdgeInsets.only(left: 24.w),
-          child: SvgPicture.asset(AppAssets.icLogoBlack, width: 88.w, height: 28.h),
-        ),
-        actions: [
-          Row(
-            spacing: 20.w,
-            children: [
-              GestureDetector(
-                onTap: () {},
-                child: SvgPicture.asset(AppAssets.icNotification, width: 24.w, height: 24.w),
-              ),
-              GestureDetector(onTap: () {}, child: SvgPicture.asset(AppAssets.icCalendar, width: 24.w, height: 24.w)),
-              GestureDetector(
-                onTap: () {},
-                child: SvgPicture.asset(AppAssets.icSearch, width: 24.w, height: 24.w),
-              ),
-            ],
-          ),
-          SizedBox(width: 24.w),
-        ],
-      ),
-      body: CustomScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        controller: _scrollController,
-        slivers: [
-          const InternationalDomesticTabView(),
-          const TodayExhibitRecommendationView(),
-          Selector<HomeViewModel, bool>(
+      body: SafeArea(
+        child: CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          controller: _scrollController,
+          slivers: [
+            _buildAppBar(),
+            _buildExhibitionTabBar(),
+            const InternationalDomesticTabView(),
+            const TodayExhibitRecommendationView(),
+            const PersonalizedExhibitionView(),
+            Selector<HomeViewModel, bool>(
               selector: (_, vm) => vm.isDomestic,
               builder: (context, isDomestic, _) {
-                return isDomestic ? const RegionalExhibitionView() : const SliverToBoxAdapter(child: SizedBox.shrink());
-              }),
-          const GenreExhibitionView(),
-          SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+                return isDomestic
+                    ? const RegionalExhibitionView()
+                    : const SliverToBoxAdapter(child: SizedBox.shrink());
+              },
+            ),
+            const GenreExhibitionView(),
+            SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  SliverToBoxAdapter _buildAppBar() {
+    return SliverToBoxAdapter(
+      child: Container(
+        color: AppColors.gray0,
+        height: 52.h,
+        padding: EdgeInsets.symmetric(horizontal: 24.w),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            SvgPicture.asset(AppAssets.icLogoBlack, width: 88.w, height: 28.h),
+            Row(
+              spacing: 20.w,
+              children: [
+                GestureDetector(
+                  onTap: () {},
+                  child: SvgPicture.asset(
+                    AppAssets.icNotification,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () {},
+                  child: SvgPicture.asset(
+                    AppAssets.icCalendar,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () {},
+                  child: SvgPicture.asset(
+                    AppAssets.icSearch,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  SliverAppBar _buildExhibitionTabBar() {
+    return SliverAppBar(
+      pinned: true,
+      toolbarHeight: 28.h + 8.h,
+      elevation: 0,
+      backgroundColor: AppColors.gray0,
+      surfaceTintColor: AppColors.gray0,
+      flexibleSpace: TabBar(
+        controller: _tabController,
+        padding: EdgeInsets.only(left: 12.w, right: 12.w, bottom: 8.h),
+        dividerHeight: 0,
+        overlayColor: WidgetStateColor.resolveWith(
+          (states) => Colors.transparent,
+        ),
+        indicator: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: AppColors.primary200, width: 2.w),
+          ),
+        ),
+        indicatorWeight: 2.h,
+        labelStyle:
+            ArtTripText.pretendard()
+                .title01Bold()
+                .color(AppColors.textPoint)
+                .build()
+                .style(),
+        unselectedLabelStyle:
+            ArtTripText.pretendard()
+                .title01Bold()
+                .color(AppColors.textTertiary)
+                .build()
+                .style(),
+        labelPadding: EdgeInsets.symmetric(horizontal: 12.w),
+        indicatorSize: TabBarIndicatorSize.label,
+        tabAlignment: TabAlignment.start,
+        isScrollable: true,
+        tabs: [
+          Tab(text: context.l10n.internationalExhibition),
+          Tab(text: context.l10n.domesticExhibition),
         ],
+        onTap: (index) {
+          var homeViewModel = Provider.of<HomeViewModel>(
+            context,
+            listen: false,
+          );
+          homeViewModel.isDomestic = index == 0 ? false : true;
+          homeViewModel.load(context);
+        },
       ),
     );
   }

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -2,8 +2,8 @@ import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/features/home/views/domestic_overseas_view.dart';
 import 'package:arttrip/features/home/views/genre_exhibition_view.dart';
-import 'package:arttrip/features/home/views/international_domestic_tab_view.dart';
 import 'package:arttrip/features/home/views/personalized_exhibition_view.dart';
 import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
@@ -46,7 +46,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           slivers: [
             _buildAppBar(),
             _buildExhibitionTabBar(),
-            const InternationalDomesticTabView(),
+            const DomesticOverseasView(),
             const TodayExhibitRecommendationView(),
             const PersonalizedExhibitionView(),
             Selector<HomeViewModel, bool>(

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -7,6 +7,7 @@ import 'package:arttrip/features/home/views/genre_exhibition_view.dart';
 import 'package:arttrip/features/home/views/personalized_exhibition_view.dart';
 import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
+import 'package:arttrip/features/home/views/weekly_exhibition_schedule_view.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -49,6 +50,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             const DomesticOverseasView(),
             const TodayExhibitRecommendationView(),
             const PersonalizedExhibitionView(),
+            const WeeklyExhibitionScheduleView(),
             Selector<HomeViewModel, bool>(
               selector: (_, vm) => vm.isDomestic,
               builder: (context, isDomestic, _) {
@@ -155,6 +157,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             context,
             listen: false,
           );
+          if (index == (homeViewModel.isDomestic ? 1 : 0)) return;
+
           homeViewModel.isDomestic = index == 0 ? false : true;
           homeViewModel.load(context);
         },

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -18,6 +18,11 @@ abstract class HomeRepository {
     String? region,
     required String genre,
   });
+  Future<List<ExhibitModel>?> fetchPersonalizedExhibitions({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  });
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -69,10 +74,11 @@ class HomeRepositoryImpl implements HomeRepository {
     String? region,
   }) async {
     try {
-      var body =
-          !isDomestic
-              ? {'isDomestic': isDomestic, 'country': country}
-              : {'isDomestic': isDomestic, 'region': region};
+      var body = {
+        'isDomestic': isDomestic,
+        if (!isDomestic) 'country': country,
+        if (isDomestic) 'region': region,
+      };
       var response = await _dio.post('/home/recommend/today', data: body);
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
@@ -135,6 +141,35 @@ class HomeRepositoryImpl implements HomeRepository {
           .toList();
     } catch (e) {
       AppUtil.debugLog('fetchExhibitionsByGenre: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchPersonalizedExhibitions({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) async {
+    try {
+      var body = {
+        'isDomestic': isDomestic,
+        if (!isDomestic) 'country': country,
+        if (isDomestic) 'region': region,
+      };
+      var response = await _dio.post('/home/personalized/random', data: body);
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog(
+          'fetchPersonalizedExhibitions type inconsistency: ${model.result.runtimeType}',
+        );
+        return null;
+      }
+      return model.result
+          .map<ExhibitModel>((e) => ExhibitModel.fromJson(e))
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchPersonalizedExhibitions: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -12,6 +12,12 @@ abstract class HomeRepository {
     String? region,
   });
   Future<List<String>?> fetchGenres();
+  Future<List<ExhibitModel>?> fetchExhibitionsByGenre({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String genre,
+  });
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -24,7 +30,9 @@ class HomeRepositoryImpl implements HomeRepository {
       var response = await _dio.get('/exhibit/overseas');
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog('fetchOverseasCountries type inconsistency: ${model.result.runtimeType}');
+        AppUtil.debugLog(
+          'fetchOverseasCountries type inconsistency: ${model.result.runtimeType}',
+        );
         return null;
       }
 
@@ -41,7 +49,9 @@ class HomeRepositoryImpl implements HomeRepository {
       var response = await _dio.get('/exhibit/domestic');
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog('fetchDomesticRegions type inconsistency: ${model.result.runtimeType}');
+        AppUtil.debugLog(
+          'fetchDomesticRegions type inconsistency: ${model.result.runtimeType}',
+        );
         return null;
       }
 
@@ -60,14 +70,20 @@ class HomeRepositoryImpl implements HomeRepository {
   }) async {
     try {
       var body =
-          !isDomestic ? {'isDomestic': isDomestic, 'country': country} : {'isDomestic': isDomestic, 'region': region};
+          !isDomestic
+              ? {'isDomestic': isDomestic, 'country': country}
+              : {'isDomestic': isDomestic, 'region': region};
       var response = await _dio.post('/home/recommend/today', data: body);
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog('fetchTodayExhibitRecommendations type inconsistency: ${model.result.runtimeType}');
+        AppUtil.debugLog(
+          'fetchTodayExhibitRecommendations type inconsistency: ${model.result.runtimeType}',
+        );
         return null;
       }
-      return model.result.map<ExhibitModel>((e) => ExhibitModel.fromJson(e)).toList();
+      return model.result
+          .map<ExhibitModel>((e) => ExhibitModel.fromJson(e))
+          .toList();
     } catch (e) {
       AppUtil.debugLog('fetchTodayExhibitRecommendations: $e');
     }
@@ -80,12 +96,45 @@ class HomeRepositoryImpl implements HomeRepository {
       var response = await _dio.get('/exhibit/genre');
       var model = BaseResultModel.fromJson(response.dataOrNull);
       if (model.result is! List) {
-        AppUtil.debugLog('fetchGenres type inconsistency: ${model.result.runtimeType}');
+        AppUtil.debugLog(
+          'fetchGenres type inconsistency: ${model.result.runtimeType}',
+        );
         return null;
       }
       return model.result.map<String>((e) => e.toString()).toList();
     } catch (e) {
       AppUtil.debugLog('fetchGenres: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchExhibitionsByGenre({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String genre,
+  }) async {
+    try {
+      var body = {
+        'isDomestic': isDomestic,
+        if (!isDomestic) 'country': country,
+        if (isDomestic) 'region': region,
+        'singleGenre': genre,
+      };
+      var response = await _dio.post('/home/genre/random', data: body);
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog(
+          'fetchExhibitionsByGenre type inconsistency: ${model.result.runtimeType}',
+        );
+        return null;
+      }
+      return model.result
+          .map<ExhibitModel>((e) => ExhibitModel.fromJson(e))
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchExhibitionsByGenre: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -23,6 +23,12 @@ abstract class HomeRepository {
     String? country,
     String? region,
   });
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  });
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -170,6 +176,37 @@ class HomeRepositoryImpl implements HomeRepository {
           .toList();
     } catch (e) {
       AppUtil.debugLog('fetchPersonalizedExhibitions: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) async {
+    try {
+      var body = {
+        'isDomestic': isDomestic,
+        if (!isDomestic) 'country': country,
+        if (isDomestic) 'region': region,
+        'date': date,
+      };
+      var response = await _dio.post('/home/personalized/random', data: body);
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog(
+          'fetchWeeklyExhibitionsBySelectedDate type inconsistency: ${model.result.runtimeType}',
+        );
+        return null;
+      }
+      return model.result
+          .map<ExhibitModel>((e) => ExhibitModel.fromJson(e))
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchWeeklyExhibitionsBySelectedDate: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -11,6 +11,7 @@ abstract class HomeRepository {
     String? country,
     String? region,
   });
+  Future<List<String>?> fetchGenres();
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -69,6 +70,22 @@ class HomeRepositoryImpl implements HomeRepository {
       return model.result.map<ExhibitModel>((e) => ExhibitModel.fromJson(e)).toList();
     } catch (e) {
       AppUtil.debugLog('fetchTodayExhibitRecommendations: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<String>?> fetchGenres() async {
+    try {
+      var response = await _dio.get('/exhibit/genre');
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog('fetchGenres type inconsistency: ${model.result.runtimeType}');
+        return null;
+      }
+      return model.result.map<String>((e) => e.toString()).toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchGenres: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository_hybrid.dart
+++ b/lib/features/home/home_repository_hybrid.dart
@@ -35,4 +35,12 @@ class HomeRepositoryHybrid implements HomeRepository {
     }
     return api.fetchTodayExhibitRecommendations(isDomestic: isDomestic, country: country, region: region);
   }
+
+  @override
+  Future<List<String>?> fetchGenres() {
+    if (AppConsts.useMock) {
+      return mock.fetchGenres();
+    }
+    return api.fetchGenres();
+  }
 }

--- a/lib/features/home/home_repository_hybrid.dart
+++ b/lib/features/home/home_repository_hybrid.dart
@@ -70,4 +70,24 @@ class HomeRepositoryHybrid implements HomeRepository {
       genre: genre,
     );
   }
+
+  @override
+  Future<List<ExhibitModel>?> fetchPersonalizedExhibitions({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) {
+    if (AppConsts.useMock) {
+      return mock.fetchPersonalizedExhibitions(
+        isDomestic: isDomestic,
+        country: country,
+        region: region,
+      );
+    }
+    return api.fetchPersonalizedExhibitions(
+      isDomestic: isDomestic,
+      country: country,
+      region: region,
+    );
+  }
 }

--- a/lib/features/home/home_repository_hybrid.dart
+++ b/lib/features/home/home_repository_hybrid.dart
@@ -90,4 +90,27 @@ class HomeRepositoryHybrid implements HomeRepository {
       region: region,
     );
   }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) {
+    if (AppConsts.useMock) {
+      return mock.fetchWeeklyExhibitionsBySelectedDate(
+        isDomestic: isDomestic,
+        country: country,
+        region: region,
+        date: date,
+      );
+    }
+    return api.fetchWeeklyExhibitionsBySelectedDate(
+      isDomestic: isDomestic,
+      country: country,
+      region: region,
+      date: date,
+    );
+  }
 }

--- a/lib/features/home/home_repository_hybrid.dart
+++ b/lib/features/home/home_repository_hybrid.dart
@@ -33,7 +33,11 @@ class HomeRepositoryHybrid implements HomeRepository {
     if (AppConsts.useMock) {
       return mock.fetchTodayExhibitRecommendations(isDomestic: isDomestic);
     }
-    return api.fetchTodayExhibitRecommendations(isDomestic: isDomestic, country: country, region: region);
+    return api.fetchTodayExhibitRecommendations(
+      isDomestic: isDomestic,
+      country: country,
+      region: region,
+    );
   }
 
   @override
@@ -42,5 +46,28 @@ class HomeRepositoryHybrid implements HomeRepository {
       return mock.fetchGenres();
     }
     return api.fetchGenres();
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchExhibitionsByGenre({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String genre,
+  }) {
+    if (AppConsts.useMock) {
+      return mock.fetchExhibitionsByGenre(
+        isDomestic: isDomestic,
+        country: country,
+        region: region,
+        genre: genre,
+      );
+    }
+    return api.fetchExhibitionsByGenre(
+      isDomestic: isDomestic,
+      country: country,
+      region: region,
+      genre: genre,
+    );
   }
 }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -1,4 +1,5 @@
 import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/app_urls.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 
@@ -8,7 +9,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchOverseasCountries() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     ); // 실제 딜레이 흉내
     return ['프랑스', '오스트리아', '중국', '일본', '독일', '대한민국'];
   }
@@ -16,7 +17,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchDomesticRegions() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return ['서울', '경기', '충청', '강원', '전라', '경상', '제주'];
   }
@@ -28,24 +29,24 @@ class HomeRepositoryMockImpl implements HomeRepository {
     String? region,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }
@@ -53,7 +54,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchGenres() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return [
       '공예',
@@ -78,25 +79,24 @@ class HomeRepositoryMockImpl implements HomeRepository {
     required String genre,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
-    // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }
@@ -108,25 +108,54 @@ class HomeRepositoryMockImpl implements HomeRepository {
     String? region,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
-    // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
+      ),
+    ];
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) async {
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
+    );
+    return [
+      ExhibitModel(
+        exhibitId: 13,
+        title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
+        posterUrl: AppUrls.posterUrlMock,
+        status: 'ONGOING',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
+      ),
+      ExhibitModel(
+        exhibitId: 12,
+        title: '눈이 타오르는 비탈',
+        posterUrl: AppUrls.posterUrlMock,
+        status: 'FINISHED',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -7,13 +7,17 @@ class HomeRepositoryMockImpl implements HomeRepository {
 
   @override
   Future<List<String>?> fetchOverseasCountries() async {
-    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis)); // 실제 딜레이 흉내
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    ); // 실제 딜레이 흉내
     return ['프랑스', '오스트리아', '중국', '일본', '독일', '대한민국'];
   }
 
   @override
   Future<List<String>?> fetchDomesticRegions() async {
-    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    );
     return ['서울', '경기', '충청', '강원', '전라', '경상', '제주'];
   }
 
@@ -23,32 +27,42 @@ class HomeRepositoryMockImpl implements HomeRepository {
     String? country,
     String? region,
   }) async {
-    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    );
     return [
       ExhibitModel(
-          exhibitId: 7,
-          title: 'Koki Tanaka: Provisional Community',
-          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
-          status: 'ONGOING',
-          exhibitPeriod: '2025-09-27 ~ 2026-01-05'),
+        exhibitId: 7,
+        title: 'Koki Tanaka: Provisional Community',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+      ),
       ExhibitModel(
-          exhibitId: 8,
-          title: 'In Sight! Lovis Corinth',
-          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-          status: 'UPCOMING',
-          exhibitPeriod: '2025-07-18 ~ 2026-01-26'),
+        exhibitId: 8,
+        title: 'In Sight! Lovis Corinth',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'UPCOMING',
+        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
+      ),
       ExhibitModel(
-          exhibitId: 1,
-          title: 'Matisse – Soulages',
-          posterUrl: 'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-          status: 'ONGOING',
-          exhibitPeriod: '2025-10-18 ~ 2026-03-09'),
+        exhibitId: 1,
+        title: 'Matisse – Soulages',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+      ),
     ];
   }
 
   @override
   Future<List<String>?> fetchGenres() async {
-    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    );
     return [
       '공예',
       '근대 미술',
@@ -61,6 +75,45 @@ class HomeRepositoryMockImpl implements HomeRepository {
       '팝아트',
       '현대 미술',
       '회화',
+    ];
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchExhibitionsByGenre({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String genre,
+  }) async {
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    );
+    // TODO: 실데이터 값으로 변경 예정
+    return [
+      ExhibitModel(
+        exhibitId: 7,
+        title: 'Koki Tanaka: Provisional Community',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+      ),
+      ExhibitModel(
+        exhibitId: 8,
+        title: 'In Sight! Lovis Corinth',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'UPCOMING',
+        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
+      ),
+      ExhibitModel(
+        exhibitId: 1,
+        title: 'Matisse – Soulages',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+      ),
     ];
   }
 }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -116,4 +116,42 @@ class HomeRepositoryMockImpl implements HomeRepository {
       ),
     ];
   }
+
+  @override
+  Future<List<ExhibitModel>?> fetchPersonalizedExhibitions({
+    required bool isDomestic,
+    String? country,
+    String? region,
+  }) async {
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+    );
+    // TODO: 실데이터 값으로 변경 예정
+    return [
+      ExhibitModel(
+        exhibitId: 7,
+        title: 'Koki Tanaka: Provisional Community',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+      ),
+      ExhibitModel(
+        exhibitId: 8,
+        title: 'In Sight! Lovis Corinth',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'UPCOMING',
+        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
+      ),
+      ExhibitModel(
+        exhibitId: 1,
+        title: 'Matisse – Soulages',
+        posterUrl:
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
+        status: 'ONGOING',
+        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+      ),
+    ];
+  }
 }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -32,28 +32,20 @@ class HomeRepositoryMockImpl implements HomeRepository {
     );
     return [
       ExhibitModel(
-        exhibitId: 7,
-        title: 'Koki Tanaka: Provisional Community',
+        exhibitId: 13,
+        title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
         status: 'ONGOING',
-        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
       ),
       ExhibitModel(
-        exhibitId: 8,
-        title: 'In Sight! Lovis Corinth',
+        exhibitId: 12,
+        title: '눈이 타오르는 비탈',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'UPCOMING',
-        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
-      ),
-      ExhibitModel(
-        exhibitId: 1,
-        title: 'Matisse – Soulages',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'ONGOING',
-        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        status: 'FINISHED',
+        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
       ),
     ];
   }
@@ -91,28 +83,20 @@ class HomeRepositoryMockImpl implements HomeRepository {
     // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
-        exhibitId: 7,
-        title: 'Koki Tanaka: Provisional Community',
+        exhibitId: 13,
+        title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
         status: 'ONGOING',
-        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
       ),
       ExhibitModel(
-        exhibitId: 8,
-        title: 'In Sight! Lovis Corinth',
+        exhibitId: 12,
+        title: '눈이 타오르는 비탈',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'UPCOMING',
-        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
-      ),
-      ExhibitModel(
-        exhibitId: 1,
-        title: 'Matisse – Soulages',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'ONGOING',
-        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        status: 'FINISHED',
+        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
       ),
     ];
   }
@@ -129,28 +113,20 @@ class HomeRepositoryMockImpl implements HomeRepository {
     // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
-        exhibitId: 7,
-        title: 'Koki Tanaka: Provisional Community',
+        exhibitId: 13,
+        title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/9dc3a4e7-6_fmi.png',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
         status: 'ONGOING',
-        exhibitPeriod: '2025-09-27 ~ 2026-01-05',
+        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
       ),
       ExhibitModel(
-        exhibitId: 8,
-        title: 'In Sight! Lovis Corinth',
+        exhibitId: 12,
+        title: '눈이 타오르는 비탈',
         posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'UPCOMING',
-        exhibitPeriod: '2025-07-18 ~ 2026-01-26',
-      ),
-      ExhibitModel(
-        exhibitId: 1,
-        title: 'Matisse – Soulages',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/01d632f0-4_fmi.png',
-        status: 'ONGOING',
-        exhibitPeriod: '2025-10-18 ~ 2026-03-09',
+            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        status: 'FINISHED',
+        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
       ),
     ];
   }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -45,4 +45,22 @@ class HomeRepositoryMockImpl implements HomeRepository {
           exhibitPeriod: '2025-10-18 ~ 2026-03-09'),
     ];
   }
+
+  @override
+  Future<List<String>?> fetchGenres() async {
+    await Future.delayed(const Duration(milliseconds: AppConsts.mockLoadingDelayMillis));
+    return [
+      '공예',
+      '근대 미술',
+      '디지털/미디어 아트',
+      '사진',
+      '설치 미술',
+      '순수 미술',
+      '역사/고전 미술',
+      '조각',
+      '팝아트',
+      '현대 미술',
+      '회화',
+    ];
+  }
 }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -40,17 +40,31 @@ class HomeViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  void _resetToLoading({bool resetLocations = true}) {
+    if (resetLocations) locations = const AsyncState.loading();
+    todayExhibitRecommendations = const AsyncState.loading();
+    genres = const AsyncState.loading();
+    exhibitionsByGenre = const AsyncState.loading();
+    personalizedExhibitions = const AsyncState.loading();
+    notifyListeners();
+  }
+
   void load(BuildContext context) {
-    _isDomestic ? fetchDomesticRegions() : fetchOverseasCountries(context);
-    fetchTodayExhibitRecommendations();
-    fetchGenres();
-    fetchPersonalizedExhibitions();
+    _resetToLoading();
+    (_isDomestic ? fetchDomesticRegions() : fetchOverseasCountries(context))
+        .then((_) {
+          fetchTodayExhibitRecommendations();
+          fetchGenres();
+          fetchPersonalizedExhibitions();
+        });
   }
 
   void updateSelectedLocation(String location) {
     _selectedLocation = location;
+    _resetToLoading(resetLocations: false);
     fetchTodayExhibitRecommendations();
     fetchGenres();
+    fetchPersonalizedExhibitions();
   }
 
   Future<void> fetchOverseasCountries(BuildContext context) async {
@@ -85,7 +99,6 @@ class HomeViewModel with ChangeNotifier {
   Future<void> fetchTodayExhibitRecommendations() async {
     todayExhibitRecommendations = const AsyncState.loading();
     notifyListeners();
-
     var result = await repository.fetchTodayExhibitRecommendations(
       isDomestic: _isDomestic,
       country: _isDomestic ? null : _selectedLocation,

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/core/app_utils.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
@@ -16,14 +17,20 @@ class HomeViewModel with ChangeNotifier {
       const AsyncState.loading();
   AsyncState<List<ExhibitModel>> personalizedExhibitions =
       const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> weeklyExhibitionsBySelectedDate =
+      const AsyncState.loading();
+  AsyncState<List<DateTime>> weeklyCalendar = const AsyncState.loading();
 
+  final DateTime _today = DateTime.now();
   bool _isDomestic = false;
   late String _selectedLocation;
   late String _selectedGenre;
+  DateTime _selectedDateInWeek = DateTime.now();
 
   bool get isDomestic => _isDomestic;
   String get selectedLocation => _selectedLocation;
   String get selectedGenre => _selectedGenre;
+  DateTime get selectedDateInWeek => _selectedDateInWeek;
 
   set isDomestic(bool value) {
     _isDomestic = value;
@@ -40,12 +47,19 @@ class HomeViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  set selectedDateInWeek(DateTime date) {
+    _selectedDateInWeek = date;
+    notifyListeners();
+  }
+
   void _resetToLoading({bool resetLocations = true}) {
     if (resetLocations) locations = const AsyncState.loading();
     todayExhibitRecommendations = const AsyncState.loading();
     genres = const AsyncState.loading();
     exhibitionsByGenre = const AsyncState.loading();
     personalizedExhibitions = const AsyncState.loading();
+    weeklyExhibitionsBySelectedDate = const AsyncState.loading();
+    weeklyCalendar = const AsyncState.loading();
     notifyListeners();
   }
 
@@ -56,6 +70,8 @@ class HomeViewModel with ChangeNotifier {
           fetchTodayExhibitRecommendations();
           fetchGenres();
           fetchPersonalizedExhibitions();
+          fetchWeeklyExhibitionsBySelectedDate(_today, isInitialLoad: true);
+          getWeeklyCalendar();
         });
   }
 
@@ -65,6 +81,13 @@ class HomeViewModel with ChangeNotifier {
     fetchTodayExhibitRecommendations();
     fetchGenres();
     fetchPersonalizedExhibitions();
+    fetchWeeklyExhibitionsBySelectedDate(_today, isInitialLoad: true);
+    getWeeklyCalendar();
+  }
+
+  void updateSelectedDateInWeek(DateTime date) {
+    selectedDateInWeek = date;
+    fetchWeeklyExhibitionsBySelectedDate(date);
   }
 
   Future<void> fetchOverseasCountries(BuildContext context) async {
@@ -159,6 +182,39 @@ class HomeViewModel with ChangeNotifier {
     } else {
       personalizedExhibitions = AsyncState.success(result);
     }
+    notifyListeners();
+  }
+
+  Future<void> fetchWeeklyExhibitionsBySelectedDate(
+    DateTime date, {
+    bool isInitialLoad = false,
+  }) async {
+    if (isInitialLoad) _selectedDateInWeek = _today;
+    weeklyExhibitionsBySelectedDate = const AsyncState.loading();
+    notifyListeners();
+
+    var result = await repository.fetchWeeklyExhibitionsBySelectedDate(
+      isDomestic: _isDomestic,
+      country: _isDomestic ? null : _selectedLocation,
+      region: _isDomestic ? _selectedLocation : null,
+      date: AppUtil.formatDateYMD(date),
+    );
+    if (result == null) {
+      weeklyExhibitionsBySelectedDate = const AsyncState.error();
+    } else {
+      weeklyExhibitionsBySelectedDate = AsyncState.success(result);
+    }
+    notifyListeners();
+  }
+
+  Future<void> getWeeklyCalendar() async {
+    weeklyCalendar = const AsyncState.loading();
+    notifyListeners();
+
+    await Future.delayed(const Duration(milliseconds: 500));
+    var result = AppUtil.getCurrentWeek(_today);
+
+    weeklyCalendar = AsyncState.success(result);
     notifyListeners();
   }
 }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -14,6 +14,8 @@ class HomeViewModel with ChangeNotifier {
   AsyncState<List<String>> genres = const AsyncState.loading();
   AsyncState<List<ExhibitModel>> exhibitionsByGenre =
       const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> personalizedExhibitions =
+      const AsyncState.loading();
 
   bool _isDomestic = false;
   late String _selectedLocation;
@@ -42,6 +44,7 @@ class HomeViewModel with ChangeNotifier {
     _isDomestic ? fetchDomesticRegions() : fetchOverseasCountries(context);
     fetchTodayExhibitRecommendations();
     fetchGenres();
+    fetchPersonalizedExhibitions();
   }
 
   void updateSelectedLocation(String location) {
@@ -125,6 +128,23 @@ class HomeViewModel with ChangeNotifier {
       exhibitionsByGenre = const AsyncState.error();
     } else {
       exhibitionsByGenre = AsyncState.success(result);
+    }
+    notifyListeners();
+  }
+
+  Future<void> fetchPersonalizedExhibitions() async {
+    personalizedExhibitions = const AsyncState.loading();
+    notifyListeners();
+
+    var result = await repository.fetchPersonalizedExhibitions(
+      isDomestic: _isDomestic,
+      country: _isDomestic ? null : _selectedLocation,
+      region: _isDomestic ? _selectedLocation : null,
+    );
+    if (result == null) {
+      personalizedExhibitions = const AsyncState.error();
+    } else {
+      personalizedExhibitions = AsyncState.success(result);
     }
     notifyListeners();
   }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -9,8 +9,11 @@ class HomeViewModel with ChangeNotifier {
   final HomeRepository repository;
 
   AsyncState<List<String>> locations = const AsyncState.loading();
-  AsyncState<List<ExhibitModel>> todayExhibitRecommendations = const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> todayExhibitRecommendations =
+      const AsyncState.loading();
   AsyncState<List<String>> genres = const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> exhibitionsByGenre =
+      const AsyncState.loading();
 
   bool _isDomestic = false;
   late String _selectedLocation;
@@ -103,6 +106,25 @@ class HomeViewModel with ChangeNotifier {
     } else {
       genres = AsyncState.success(result);
       _selectedGenre = result.first;
+    }
+    notifyListeners();
+    await fetchExhibitsByGenre();
+  }
+
+  Future<void> fetchExhibitsByGenre() async {
+    exhibitionsByGenre = const AsyncState.loading();
+    notifyListeners();
+
+    var result = await repository.fetchExhibitionsByGenre(
+      isDomestic: _isDomestic,
+      country: _isDomestic ? null : _selectedLocation,
+      region: _isDomestic ? _selectedLocation : null,
+      genre: _selectedGenre,
+    );
+    if (result == null) {
+      exhibitionsByGenre = const AsyncState.error();
+    } else {
+      exhibitionsByGenre = AsyncState.success(result);
     }
     notifyListeners();
   }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -36,7 +36,13 @@ class HomeViewModel with ChangeNotifier {
   }
 
   void load(BuildContext context) {
-    fetchOverseasCountries(context);
+    _isDomestic ? fetchDomesticRegions() : fetchOverseasCountries(context);
+    fetchTodayExhibitRecommendations();
+    fetchGenres();
+  }
+
+  void updateSelectedLocation(String location) {
+    _selectedLocation = location;
     fetchTodayExhibitRecommendations();
     fetchGenres();
   }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -10,26 +10,35 @@ class HomeViewModel with ChangeNotifier {
 
   AsyncState<List<String>> locations = const AsyncState.loading();
   AsyncState<List<ExhibitModel>> todayExhibitRecommendations = const AsyncState.loading();
+  AsyncState<List<String>> genres = const AsyncState.loading();
 
   bool _isDomestic = false;
   late String _selectedLocation;
+  late String _selectedGenre;
 
   bool get isDomestic => _isDomestic;
   String get selectedLocation => _selectedLocation;
+  String get selectedGenre => _selectedGenre;
 
   set isDomestic(bool value) {
     _isDomestic = value;
     notifyListeners();
   }
 
-  void load(BuildContext context) {
-    fetchOverseasCountries(context);
-    fetchTodayExhibitRecommendations();
-  }
-
   set selectedLocation(String region) {
     _selectedLocation = region;
     notifyListeners();
+  }
+
+  set selectedGenre(String genre) {
+    _selectedGenre = genre;
+    notifyListeners();
+  }
+
+  void load(BuildContext context) {
+    fetchOverseasCountries(context);
+    fetchTodayExhibitRecommendations();
+    fetchGenres();
   }
 
   Future<void> fetchOverseasCountries(BuildContext context) async {
@@ -74,6 +83,20 @@ class HomeViewModel with ChangeNotifier {
       todayExhibitRecommendations = const AsyncState.error();
     } else {
       todayExhibitRecommendations = AsyncState.success(result);
+    }
+    notifyListeners();
+  }
+
+  Future<void> fetchGenres() async {
+    genres = const AsyncState.loading();
+    notifyListeners();
+
+    var result = await repository.fetchGenres();
+    if (result == null) {
+      genres = const AsyncState.error();
+    } else {
+      genres = AsyncState.success(result);
+      _selectedGenre = result.first;
     }
     notifyListeners();
   }

--- a/lib/features/home/views/domestic_overseas_view.dart
+++ b/lib/features/home/views/domestic_overseas_view.dart
@@ -1,21 +1,22 @@
 import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
 
-class InternationalDomesticTabView extends StatefulWidget {
-  const InternationalDomesticTabView({super.key});
+class DomesticOverseasView extends StatefulWidget {
+  const DomesticOverseasView({super.key});
 
   @override
-  State<InternationalDomesticTabView> createState() =>
-      _InternationalDomesticTabViewState();
+  State<DomesticOverseasView> createState() => _DomesticOverseasViewState();
 }
 
-class _InternationalDomesticTabViewState
-    extends State<InternationalDomesticTabView> {
+class _DomesticOverseasViewState extends State<DomesticOverseasView> {
   List<GlobalKey>? _itemKeys;
 
   void _updateSelectedLocation(int index, String location) {
@@ -64,6 +65,34 @@ class _InternationalDomesticTabViewState
                       data[index],
                     );
                   },
+                );
+              },
+              onLoading: () {
+                return Shimmer(
+                  duration: const Duration(
+                    milliseconds: AppConsts.shimmerDurationMs,
+                  ),
+                  interval: const Duration(
+                    milliseconds: AppConsts.shimmerIntervalMs,
+                  ),
+                  child: SizedBox(
+                    height: 64.h,
+                    child: ListView.separated(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      scrollDirection: Axis.horizontal,
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 24.w,
+                        vertical: 16.h,
+                      ),
+                      itemCount: 5,
+                      separatorBuilder:
+                          (context, index) => SizedBox(width: 8.w),
+                      itemBuilder: (context, index) {
+                        return const ShimmerSkeletonItem(width: 76, height: 32);
+                      },
+                    ),
+                  ),
                 );
               },
             );

--- a/lib/features/home/views/genre_exhibition_view.dart
+++ b/lib/features/home/views/genre_exhibition_view.dart
@@ -1,15 +1,19 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
 import 'package:arttrip/shared/widgets/exhibition_list_item.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item_skeleton.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
 
 class GenreExhibitionView extends StatefulWidget {
   const GenreExhibitionView({super.key});
@@ -53,6 +57,8 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
                 child: Column(
                   children: [
                     _buildHeader(),
+
+                    /// 장르 리스트
                     SizedBox(
                       height: 64.h,
                       child: ListView.separated(
@@ -74,32 +80,116 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
                         },
                       ),
                     ),
+
+                    /// 장르별 랜덤 전시
                     Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
                       selector: (_, vm) => vm.exhibitionsByGenre,
                       builder: (context, state, _) {
                         return AsyncView(
                           state: state,
                           onData: (data) {
-                            return SizedBox(
-                              height: 100.h,
-                              child: ListView.separated(
-                                physics: const NeverScrollableScrollPhysics(),
-                                shrinkWrap: true,
-                                itemCount: data.length,
-                                padding: EdgeInsets.symmetric(horizontal: 24.w),
-                                separatorBuilder:
-                                    (context, index) => SizedBox(height: 8.h),
-                                itemBuilder: (context, index) {
-                                  var item = data[index];
-                                  return ExhibitionListItem(item: item);
-                                },
-                              ),
+                            return ListView.separated(
+                              physics: const NeverScrollableScrollPhysics(),
+                              shrinkWrap: true,
+                              itemCount: data.length,
+                              padding: EdgeInsets.symmetric(horizontal: 24.w),
+                              separatorBuilder:
+                                  (context, index) => SizedBox(height: 8.h),
+                              itemBuilder: (context, index) {
+                                var item = data[index];
+                                return ExhibitionListItem(item: item);
+                              },
                             );
                           },
+                          onLoading:
+                              () => Shimmer(
+                                duration: const Duration(
+                                  milliseconds: AppConsts.shimmerDurationMs,
+                                ),
+                                interval: const Duration(
+                                  milliseconds: AppConsts.shimmerIntervalMs,
+                                ),
+                                child: ListView.separated(
+                                  shrinkWrap: true,
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: 24.w,
+                                  ),
+                                  itemCount: 2,
+                                  separatorBuilder:
+                                      (context, index) => SizedBox(height: 8.h),
+                                  itemBuilder: (context, index) {
+                                    return const ExhibitionListItemSkeleton();
+                                  },
+                                ),
+                              ),
                         );
                       },
                     ),
                   ],
+                ),
+              );
+            },
+            onLoading: () {
+              return Shimmer(
+                duration: const Duration(
+                  milliseconds: AppConsts.shimmerDurationMs,
+                ),
+                interval: const Duration(
+                  milliseconds: AppConsts.shimmerIntervalMs,
+                ),
+                child: Padding(
+                  padding: EdgeInsets.only(top: 28.h),
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 24.w),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const ShimmerSkeletonItem(width: 160, height: 20),
+                            SvgPicture.asset(
+                              AppAssets.icNoArrowRight,
+                              width: 24.w,
+                              height: 24.w,
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(
+                        height: 64.h,
+                        child: ListView.separated(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          scrollDirection: Axis.horizontal,
+                          padding: EdgeInsets.symmetric(
+                            horizontal: 24.w,
+                            vertical: 16.h,
+                          ),
+                          itemCount: 5,
+                          separatorBuilder:
+                              (context, index) => SizedBox(width: 8.w),
+                          itemBuilder: (context, index) {
+                            return const ShimmerSkeletonItem(
+                              width: 76,
+                              height: 32,
+                            );
+                          },
+                        ),
+                      ),
+                      ListView.separated(
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        padding: EdgeInsets.symmetric(horizontal: 24.w),
+                        itemCount: 2,
+                        separatorBuilder:
+                            (context, index) => SizedBox(height: 8.h),
+                        itemBuilder: (context, index) {
+                          return const ExhibitionListItemSkeleton();
+                        },
+                      ),
+                    ],
+                  ),
                 ),
               );
             },

--- a/lib/features/home/views/genre_exhibition_view.dart
+++ b/lib/features/home/views/genre_exhibition_view.dart
@@ -2,8 +2,10 @@ import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -22,6 +24,7 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
   void _updateSelectedGenre(int index, String genre) {
     var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
     homeViewModel.selectedGenre = genre;
+    homeViewModel.fetchExhibitsByGenre();
     if (_itemKeys![index].currentContext != null) {
       Scrollable.ensureVisible(
         _itemKeys![index].currentContext!,
@@ -35,52 +38,74 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
       child: Selector<HomeViewModel, AsyncState<List<String>>>(
-          selector: (_, vm) => vm.genres,
-          builder: (context, state, _) {
-            return AsyncView(
-                state: state,
-                onData: (data) {
-                  if (data.isEmpty) return const SizedBox.shrink();
+        selector: (_, vm) => vm.genres,
+        builder: (context, state, _) {
+          return AsyncView(
+            state: state,
+            onData: (data) {
+              if (data.isEmpty) return const SizedBox.shrink();
 
-                  var itemCount = data.length;
-                  _itemKeys = List.generate(itemCount, (_) => GlobalKey());
+              var itemCount = data.length;
+              _itemKeys = List.generate(itemCount, (_) => GlobalKey());
 
-                  return Padding(
-                    padding: EdgeInsetsGeometry.only(top: 32.h),
-                    child: ListView.builder(
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      itemCount: 3,
-                      itemBuilder: (context, index) {
-                        switch (index) {
-                          case 0:
-                            return _buildHeader();
-                          case 1:
+              return Padding(
+                padding: EdgeInsetsGeometry.only(top: 32.h),
+                child: Column(
+                  children: [
+                    _buildHeader(),
+                    SizedBox(
+                      height: 64.h,
+                      child: ListView.separated(
+                        shrinkWrap: true,
+                        itemCount: itemCount,
+                        scrollDirection: Axis.horizontal,
+                        padding: EdgeInsets.symmetric(
+                          vertical: 16.h,
+                          horizontal: 24.w,
+                        ),
+                        separatorBuilder:
+                            (context, index) => SizedBox(width: 8.w),
+                        itemBuilder: (context, index) {
+                          return _buildGenreItem(
+                            _itemKeys![index],
+                            index,
+                            data[index],
+                          );
+                        },
+                      ),
+                    ),
+                    Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
+                      selector: (_, vm) => vm.exhibitionsByGenre,
+                      builder: (context, state, _) {
+                        return AsyncView(
+                          state: state,
+                          onData: (data) {
                             return SizedBox(
-                              height: 64.h,
+                              height: 100.h,
                               child: ListView.separated(
+                                physics: const NeverScrollableScrollPhysics(),
                                 shrinkWrap: true,
-                                itemCount: itemCount,
-                                scrollDirection: Axis.horizontal,
-                                padding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 24.w),
-                                separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                                itemCount: data.length,
+                                padding: EdgeInsets.symmetric(horizontal: 24.w),
+                                separatorBuilder:
+                                    (context, index) => SizedBox(height: 8.h),
                                 itemBuilder: (context, index) {
-                                  return _buildGenreItem(
-                                    _itemKeys![index],
-                                    index,
-                                    data[index],
-                                  );
+                                  var item = data[index];
+                                  return ExhibitionListItem(item: item);
                                 },
                               ),
                             );
-                          default:
-                            return const SizedBox.shrink();
-                        }
+                          },
+                        );
                       },
                     ),
-                  );
-                });
-          }),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 
@@ -92,9 +117,15 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
         color: Colors.transparent,
         child: Row(
           children: [
-            ArtTripText.pretendard().title01Bold().build().text(context.l10n.recommendedGenreExhibition),
+            ArtTripText.pretendard().title01Bold().build().text(
+              context.l10n.recommendedGenreExhibition,
+            ),
             const Expanded(child: SizedBox.shrink()),
-            SvgPicture.asset(AppAssets.icNoArrowRight, width: 24.w, height: 24.w),
+            SvgPicture.asset(
+              AppAssets.icNoArrowRight,
+              width: 24.w,
+              height: 24.w,
+            ),
           ],
         ),
       ),
@@ -105,7 +136,9 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
     return GestureDetector(
       onTap: () {
         var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-        if (homeViewModel.selectedGenre != genre) _updateSelectedGenre(index, genre);
+        if (homeViewModel.selectedGenre != genre) {
+          _updateSelectedGenre(index, genre);
+        }
       },
       child: Selector<HomeViewModel, String>(
         selector: (_, vm) => vm.selectedGenre,
@@ -118,7 +151,10 @@ class _GenreExhibitionViewState extends State<GenreExhibitionView> {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(100),
               color: isSelected ? AppColors.primary300 : AppColors.gray0,
-              border: Border.all(color: isSelected ? AppColors.primary300 : AppColors.gray100, width: 1.w),
+              border: Border.all(
+                color: isSelected ? AppColors.primary300 : AppColors.gray100,
+                width: 1.w,
+              ),
             ),
             child: ArtTripText.pretendard()
                 .body01Bold()

--- a/lib/features/home/views/genre_exhibition_view.dart
+++ b/lib/features/home/views/genre_exhibition_view.dart
@@ -1,0 +1,133 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+
+class GenreExhibitionView extends StatefulWidget {
+  const GenreExhibitionView({super.key});
+
+  @override
+  State<GenreExhibitionView> createState() => _GenreExhibitionViewState();
+}
+
+class _GenreExhibitionViewState extends State<GenreExhibitionView> {
+  List<GlobalKey>? _itemKeys;
+
+  void _updateSelectedGenre(int index, String genre) {
+    var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
+    homeViewModel.selectedGenre = genre;
+    if (_itemKeys![index].currentContext != null) {
+      Scrollable.ensureVisible(
+        _itemKeys![index].currentContext!,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 500),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Selector<HomeViewModel, AsyncState<List<String>>>(
+          selector: (_, vm) => vm.genres,
+          builder: (context, state, _) {
+            return AsyncView(
+                state: state,
+                onData: (data) {
+                  if (data.isEmpty) return const SizedBox.shrink();
+
+                  var itemCount = data.length;
+                  _itemKeys = List.generate(itemCount, (_) => GlobalKey());
+
+                  return Padding(
+                    padding: EdgeInsetsGeometry.only(top: 32.h),
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: 3,
+                      itemBuilder: (context, index) {
+                        switch (index) {
+                          case 0:
+                            return _buildHeader();
+                          case 1:
+                            return SizedBox(
+                              height: 64.h,
+                              child: ListView.separated(
+                                shrinkWrap: true,
+                                itemCount: itemCount,
+                                scrollDirection: Axis.horizontal,
+                                padding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 24.w),
+                                separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                                itemBuilder: (context, index) {
+                                  return _buildGenreItem(
+                                    _itemKeys![index],
+                                    index,
+                                    data[index],
+                                  );
+                                },
+                              ),
+                            );
+                          default:
+                            return const SizedBox.shrink();
+                        }
+                      },
+                    ),
+                  );
+                });
+          }),
+    );
+  }
+
+  GestureDetector _buildHeader() {
+    return GestureDetector(
+      onTap: () {},
+      child: Container(
+        padding: EdgeInsets.only(left: 24.w, right: 24.w, bottom: 2.h),
+        color: Colors.transparent,
+        child: Row(
+          children: [
+            ArtTripText.pretendard().title01Bold().build().text(context.l10n.recommendedGenreExhibition),
+            const Expanded(child: SizedBox.shrink()),
+            SvgPicture.asset(AppAssets.icNoArrowRight, width: 24.w, height: 24.w),
+          ],
+        ),
+      ),
+    );
+  }
+
+  GestureDetector _buildGenreItem(GlobalKey key, int index, String genre) {
+    return GestureDetector(
+      onTap: () {
+        var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
+        if (homeViewModel.selectedGenre != genre) _updateSelectedGenre(index, genre);
+      },
+      child: Selector<HomeViewModel, String>(
+        selector: (_, vm) => vm.selectedGenre,
+        builder: (context, selectedGenreIndex, _) {
+          var isSelected = genre == selectedGenreIndex;
+          return Container(
+            key: key,
+            padding: EdgeInsets.symmetric(vertical: 8.h, horizontal: 20.w),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(100),
+              color: isSelected ? AppColors.primary300 : AppColors.gray0,
+              border: Border.all(color: isSelected ? AppColors.primary300 : AppColors.gray100, width: 1.w),
+            ),
+            child: ArtTripText.pretendard()
+                .body01Bold()
+                .color(isSelected ? AppColors.textWhite : AppColors.textPrimary)
+                .build()
+                .text(genre),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/home/views/international_domestic_tab_view.dart
+++ b/lib/features/home/views/international_domestic_tab_view.dart
@@ -1,5 +1,4 @@
 import 'package:arttrip/core/app_colors.dart';
-import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
@@ -16,15 +15,8 @@ class InternationalDomesticTabView extends StatefulWidget {
 }
 
 class _InternationalDomesticTabViewState
-    extends State<InternationalDomesticTabView> with TickerProviderStateMixin {
+    extends State<InternationalDomesticTabView> {
   List<GlobalKey>? _itemKeys;
-  late TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-  }
 
   void _updateSelectedLocation(int index, String location) {
     var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
@@ -40,101 +32,52 @@ class _InternationalDomesticTabViewState
 
   @override
   Widget build(BuildContext context) {
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((context, index) {
-        switch (index) {
-          /// tabbar
-          case 0:
-            return _buildExhibitionTabBar();
+    return SliverToBoxAdapter(
+      child: SizedBox(
+        height: 64.h,
+        child: Selector<HomeViewModel, AsyncState<List<String>>>(
+          selector: (_, vm) => vm.locations,
+          builder: (context, state, _) {
+            return AsyncView(
+              state: state,
+              onData: (data) {
+                if (data.isEmpty) return const SizedBox.shrink();
 
-          /// countries
-          case 1:
-            return SizedBox(
-              height: 64.h,
-              child: Selector<HomeViewModel, AsyncState<List<String>>>(
-                selector: (_, vm) => vm.locations,
-                builder: (context, state, _) {
-                  return AsyncView(
-                    state: state,
-                    onData: (data) {
-                      if (data.isEmpty) return const SizedBox.shrink();
+                var itemCount = data.length;
+                _itemKeys = List.generate(itemCount, (_) => GlobalKey());
 
-                      var itemCount = data.length;
-                      _itemKeys = List.generate(itemCount, (_) => GlobalKey());
-
-                      return ListView.separated(
-                        shrinkWrap: true,
-                        itemCount: itemCount,
-                        scrollDirection: Axis.horizontal,
-                        padding: EdgeInsets.symmetric(
-                            vertical: 16.h, horizontal: 24.w),
-                        separatorBuilder: (context, index) =>
-                            SizedBox(width: 8.w),
-                        itemBuilder: (context, index) {
-                          return _buildLocationItem(
-                            _itemKeys![index],
-                            index,
-                            data[index],
-                          );
-                        },
-                      );
-                    },
-                  );
-                },
-              ),
+                return ListView.separated(
+                  shrinkWrap: true,
+                  itemCount: itemCount,
+                  scrollDirection: Axis.horizontal,
+                  padding: EdgeInsets.only(
+                    left: 24.w,
+                    top: 8.h,
+                    right: 24.w,
+                    bottom: 16.h,
+                  ),
+                  separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                  itemBuilder: (context, index) {
+                    return _buildLocationItem(
+                      _itemKeys![index],
+                      index,
+                      data[index],
+                    );
+                  },
+                );
+              },
             );
-
-          default:
-            return const SizedBox.shrink();
-        }
-      }, childCount: 2),
-    );
-  }
-
-  Container _buildExhibitionTabBar() {
-    return Container(
-      height: 28.h,
-      margin: EdgeInsets.only(top: 16.h),
-      child: TabBar(
-        controller: _tabController,
-        padding: EdgeInsets.symmetric(horizontal: 12.w),
-        dividerHeight: 0,
-        overlayColor:
-            WidgetStateColor.resolveWith((states) => Colors.transparent),
-        indicator: BoxDecoration(
-            border: Border(
-                bottom: BorderSide(color: AppColors.primary200, width: 2.w))),
-        indicatorWeight: 2.h,
-        labelStyle: ArtTripText.pretendard()
-            .title01Bold()
-            .color(AppColors.textPoint)
-            .build()
-            .style(),
-        unselectedLabelStyle: ArtTripText.pretendard()
-            .title01Bold()
-            .color(AppColors.textTertiary)
-            .build()
-            .style(),
-        labelPadding: EdgeInsets.symmetric(horizontal: 12.w),
-        indicatorSize: TabBarIndicatorSize.label,
-        tabAlignment: TabAlignment.start,
-        isScrollable: true,
-        tabs: [
-          Tab(text: context.l10n.internationalExhibition),
-          Tab(text: context.l10n.domesticExhibition)
-        ],
-        onTap: (index) {
-          var homeViewModel =
-              Provider.of<HomeViewModel>(context, listen: false);
-          homeViewModel.isDomestic = index == 0 ? false : true;
-          homeViewModel.load(context);
-        },
+          },
+        ),
       ),
     );
   }
 
   GestureDetector _buildLocationItem(
-      GlobalKey key, int index, String location) {
+    GlobalKey key,
+    int index,
+    String location,
+  ) {
     return GestureDetector(
       onTap: () {
         var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
@@ -154,8 +97,9 @@ class _InternationalDomesticTabViewState
               borderRadius: BorderRadius.circular(100),
               color: isSelected ? AppColors.primary300 : AppColors.gray0,
               border: Border.all(
-                  color: isSelected ? AppColors.primary300 : AppColors.gray100,
-                  width: 1.w),
+                color: isSelected ? AppColors.primary300 : AppColors.gray100,
+                width: 1.w,
+              ),
             ),
             child: ArtTripText.pretendard()
                 .body01Bold()

--- a/lib/features/home/views/international_domestic_tab_view.dart
+++ b/lib/features/home/views/international_domestic_tab_view.dart
@@ -11,10 +11,12 @@ class InternationalDomesticTabView extends StatefulWidget {
   const InternationalDomesticTabView({super.key});
 
   @override
-  State<InternationalDomesticTabView> createState() => _InternationalDomesticTabViewState();
+  State<InternationalDomesticTabView> createState() =>
+      _InternationalDomesticTabViewState();
 }
 
-class _InternationalDomesticTabViewState extends State<InternationalDomesticTabView> with TickerProviderStateMixin {
+class _InternationalDomesticTabViewState
+    extends State<InternationalDomesticTabView> with TickerProviderStateMixin {
   List<GlobalKey>? _itemKeys;
   late TabController _tabController;
 
@@ -26,8 +28,7 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
 
   void _updateSelectedLocation(int index, String location) {
     var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-    homeViewModel.selectedLocation = location;
-    homeViewModel.fetchTodayExhibitRecommendations();
+    homeViewModel.updateSelectedLocation(location);
     if (_itemKeys![index].currentContext != null) {
       Scrollable.ensureVisible(
         _itemKeys![index].currentContext!,
@@ -65,8 +66,10 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
                         shrinkWrap: true,
                         itemCount: itemCount,
                         scrollDirection: Axis.horizontal,
-                        padding: EdgeInsets.symmetric(vertical: 16.h, horizontal: 24.w),
-                        separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                        padding: EdgeInsets.symmetric(
+                            vertical: 16.h, horizontal: 24.w),
+                        separatorBuilder: (context, index) =>
+                            SizedBox(width: 8.w),
                         itemBuilder: (context, index) {
                           return _buildLocationItem(
                             _itemKeys![index],
@@ -96,34 +99,48 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
         controller: _tabController,
         padding: EdgeInsets.symmetric(horizontal: 12.w),
         dividerHeight: 0,
-        overlayColor: WidgetStateColor.resolveWith((states) => Colors.transparent),
-        indicator: BoxDecoration(border: Border(bottom: BorderSide(color: AppColors.primary200, width: 2.w))),
+        overlayColor:
+            WidgetStateColor.resolveWith((states) => Colors.transparent),
+        indicator: BoxDecoration(
+            border: Border(
+                bottom: BorderSide(color: AppColors.primary200, width: 2.w))),
         indicatorWeight: 2.h,
-        labelStyle: ArtTripText.pretendard().title01Bold().color(AppColors.textPoint).build().style(),
-        unselectedLabelStyle: ArtTripText.pretendard().title01Bold().color(AppColors.textTertiary).build().style(),
+        labelStyle: ArtTripText.pretendard()
+            .title01Bold()
+            .color(AppColors.textPoint)
+            .build()
+            .style(),
+        unselectedLabelStyle: ArtTripText.pretendard()
+            .title01Bold()
+            .color(AppColors.textTertiary)
+            .build()
+            .style(),
         labelPadding: EdgeInsets.symmetric(horizontal: 12.w),
         indicatorSize: TabBarIndicatorSize.label,
         tabAlignment: TabAlignment.start,
         isScrollable: true,
-        tabs: [Tab(text: context.l10n.internationalExhibition), Tab(text: context.l10n.domesticExhibition)],
+        tabs: [
+          Tab(text: context.l10n.internationalExhibition),
+          Tab(text: context.l10n.domesticExhibition)
+        ],
         onTap: (index) {
-          var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
+          var homeViewModel =
+              Provider.of<HomeViewModel>(context, listen: false);
           homeViewModel.isDomestic = index == 0 ? false : true;
-          if (index == 0) {
-            homeViewModel.fetchOverseasCountries(context);
-          } else {
-            homeViewModel.fetchDomesticRegions();
-          }
+          homeViewModel.load(context);
         },
       ),
     );
   }
 
-  GestureDetector _buildLocationItem(GlobalKey key, int index, String location) {
+  GestureDetector _buildLocationItem(
+      GlobalKey key, int index, String location) {
     return GestureDetector(
       onTap: () {
         var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-        if (homeViewModel.selectedLocation != location) _updateSelectedLocation(index, location);
+        if (homeViewModel.selectedLocation != location) {
+          _updateSelectedLocation(index, location);
+        }
       },
       child: Selector<HomeViewModel, String>(
         selector: (_, vm) => vm.selectedLocation,
@@ -136,7 +153,9 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(100),
               color: isSelected ? AppColors.primary300 : AppColors.gray0,
-              border: Border.all(color: isSelected ? AppColors.primary300 : AppColors.gray100, width: 1.w),
+              border: Border.all(
+                  color: isSelected ? AppColors.primary300 : AppColors.gray100,
+                  width: 1.w),
             ),
             child: ArtTripText.pretendard()
                 .body01Bold()

--- a/lib/features/home/views/international_domestic_tab_view.dart
+++ b/lib/features/home/views/international_domestic_tab_view.dart
@@ -24,7 +24,7 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
     _tabController = TabController(length: 2, vsync: this);
   }
 
-  void _updateSelectedLocationIndex(int index, String location) {
+  void _updateSelectedLocation(int index, String location) {
     var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
     homeViewModel.selectedLocation = location;
     homeViewModel.fetchTodayExhibitRecommendations();
@@ -123,7 +123,7 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
     return GestureDetector(
       onTap: () {
         var homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
-        if (homeViewModel.selectedLocation != location) _updateSelectedLocationIndex(index, location);
+        if (homeViewModel.selectedLocation != location) _updateSelectedLocation(index, location);
       },
       child: Selector<HomeViewModel, String>(
         selector: (_, vm) => vm.selectedLocation,
@@ -131,7 +131,7 @@ class _InternationalDomesticTabViewState extends State<InternationalDomesticTabV
           var isSelected = location == selectedLocationIndex;
           return Container(
             key: key,
-            padding: EdgeInsets.symmetric(horizontal: 20.w),
+            padding: EdgeInsets.symmetric(vertical: 8.h, horizontal: 20.w),
             alignment: Alignment.center,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(100),

--- a/lib/features/home/views/personalized_exhibition_view.dart
+++ b/lib/features/home/views/personalized_exhibition_view.dart
@@ -1,0 +1,120 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+
+class PersonalizedExhibitionView extends StatefulWidget {
+  const PersonalizedExhibitionView({super.key});
+
+  @override
+  State<PersonalizedExhibitionView> createState() =>
+      _PersonalizedExhibitionViewState();
+}
+
+class _PersonalizedExhibitionViewState
+    extends State<PersonalizedExhibitionView> {
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
+        selector: (_, vm) => vm.personalizedExhibitions,
+        builder: (context, state, _) {
+          return AsyncView(
+            state: state,
+            onData: (data) {
+              if (data.isEmpty) return const SizedBox.shrink();
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12.h,
+                children: [
+                  // TODO: 유저 이름 동적으로 바꾸기
+                  Padding(
+                    padding: EdgeInsets.only(
+                      left: 24.w,
+                      top: 32.h,
+                      right: 24.w,
+                    ),
+                    child: ArtTripText.pretendard().title01Bold().build().text(
+                      context.l10n.personalizedRecommendationTitle('김미미'),
+                    ),
+                  ),
+                  SizedBox(
+                    height: 190.h,
+                    child: ListView.separated(
+                      shrinkWrap: true,
+                      itemCount: data.length,
+                      scrollDirection: Axis.horizontal,
+                      padding: EdgeInsets.symmetric(horizontal: 24.w),
+                      separatorBuilder:
+                          (context, index) => SizedBox(width: 8.w),
+                      itemBuilder: (_, index) {
+                        var item = data[index];
+                        return GestureDetector(
+                          onTap: () {
+                            // TODO: 전시 상세 페이지로 이동
+                          },
+                          child: SizedBox(
+                            width: 120.w,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                /// 전시 이미지
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(8.r),
+                                  child: Stack(
+                                    children: [
+                                      item.posterUrl?.isNotEmpty == true
+                                          ? CachedNetworkImage(
+                                            imageUrl: item.posterUrl!,
+                                            width: 120.w,
+                                            height: 150.h,
+                                            fit: BoxFit.cover,
+                                          )
+                                          : const SizedBox.shrink(),
+                                      Positioned(
+                                        top: 8.h,
+                                        right: 8.w,
+                                        child: GestureDetector(
+                                          onTap: () {
+                                            // TODO: isLiked 동적으로 바꾸기
+                                          },
+                                          child: SvgPicture.asset(
+                                            AppAssets.icLikeCircle(
+                                              isLiked: false,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+
+                                /// 전시 제목
+                                ArtTripText.pretendard()
+                                    .body01Bold()
+                                    .ellipsis(2)
+                                    .build()
+                                    .text(item.title ?? ''),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/home/views/personalized_exhibition_view.dart
+++ b/lib/features/home/views/personalized_exhibition_view.dart
@@ -1,14 +1,17 @@
 import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
 
 class PersonalizedExhibitionView extends StatefulWidget {
   const PersonalizedExhibitionView({super.key});
@@ -63,6 +66,7 @@ class _PersonalizedExhibitionViewState
                           child: SizedBox(
                             width: 120.w,
                             child: Column(
+                              spacing: 8.h,
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 /// 전시 이미지
@@ -89,6 +93,8 @@ class _PersonalizedExhibitionViewState
                                             AppAssets.icLikeCircle(
                                               isLiked: false,
                                             ),
+                                            width: 24.w,
+                                            height: 24.w,
                                           ),
                                         ),
                                       ),
@@ -110,6 +116,66 @@ class _PersonalizedExhibitionViewState
                     ),
                   ),
                 ],
+              );
+            },
+            onLoading: () {
+              return Shimmer(
+                duration: const Duration(
+                  milliseconds: AppConsts.shimmerDurationMs,
+                ),
+                interval: const Duration(
+                  milliseconds: AppConsts.shimmerIntervalMs,
+                ),
+                child: Padding(
+                  padding: EdgeInsets.only(top: 32.h),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 12.h,
+                    children: [
+                      ShimmerSkeletonItem(
+                        width: 160,
+                        height: 20,
+                        margin: EdgeInsets.symmetric(horizontal: 24.w),
+                      ),
+                      SizedBox(
+                        height: 190.h,
+                        child: ListView.separated(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          padding: EdgeInsets.symmetric(horizontal: 24.w),
+                          scrollDirection: Axis.horizontal,
+                          itemCount: 3,
+                          separatorBuilder:
+                              (context, index) => SizedBox(width: 8.w),
+                          itemBuilder: (context, index) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const ShimmerSkeletonItem(
+                                  width: 120,
+                                  height: 150,
+                                  radius: 8,
+                                ),
+                                SizedBox(height: 8.h),
+                                const ShimmerSkeletonItem(
+                                  width: 120,
+                                  height: 14,
+                                  radius: 8,
+                                ),
+                                SizedBox(height: 4.h),
+                                const ShimmerSkeletonItem(
+                                  width: 120,
+                                  height: 14,
+                                  radius: 8,
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               );
             },
           );

--- a/lib/features/home/views/regional_exhibition_view.dart
+++ b/lib/features/home/views/regional_exhibition_view.dart
@@ -18,54 +18,57 @@ class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
   Widget build(BuildContext context) {
     return SliverPadding(
       padding: EdgeInsetsGeometry.only(top: 32.h),
-      sliver: SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            switch (index) {
-              case 0:
-                return Padding(
-                  padding: EdgeInsets.only(left: 24.w, right: 24.w, bottom: 12.h),
-                  child: ArtTripText.pretendard().title01Bold().build().text(context.l10n.regionalExhibition),
+      sliver: SliverToBoxAdapter(
+        child: Selector<HomeViewModel, AsyncState<List<String>>>(
+          selector: (_, vm) => vm.locations,
+          builder: (context, state, _) {
+            return AsyncView(
+              state: state,
+              onData: (data) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(
+                          left: 24.w, right: 24.w, bottom: 12.h),
+                      child: ArtTripText.pretendard()
+                          .title01Bold()
+                          .build()
+                          .text(context.l10n.regionalExhibition),
+                    ),
+                    SizedBox(
+                      height: 90.h,
+                      child: ListView.separated(
+                        shrinkWrap: true,
+                        scrollDirection: Axis.horizontal,
+                        itemCount: data.length,
+                        padding: EdgeInsets.symmetric(horizontal: 24.w),
+                        separatorBuilder: (context, index) =>
+                            SizedBox(width: 8.w),
+                        itemBuilder: (context, index) {
+                          var item = data[index];
+                          return Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              CircleAvatar(
+                                radius: 32.w,
+                                backgroundColor: Colors.black,
+                              ),
+                              ArtTripText.pretendard()
+                                  .body02Bold()
+                                  .textAlign(TextAlign.center)
+                                  .build()
+                                  .text(item),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 );
-              case 1:
-                return Selector<HomeViewModel, AsyncState<List<String>>>(
-                  selector: (_, vm) => vm.locations,
-                  builder: (context, state, _) {
-                    return AsyncView(
-                      state: state,
-                      onData: (data) {
-                        return SizedBox(
-                          height: 90.h,
-                          child: ListView.separated(
-                            shrinkWrap: true,
-                            scrollDirection: Axis.horizontal,
-                            itemCount: data.length,
-                            padding: EdgeInsets.symmetric(horizontal: 24.w),
-                            separatorBuilder: (context, index) => SizedBox(width: 8.w),
-                            itemBuilder: (context, index) {
-                              var item = data[index];
-                              return Column(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
-                                  CircleAvatar(
-                                    radius: 32.w,
-                                    backgroundColor: Colors.black,
-                                  ),
-                                  ArtTripText.pretendard().body02Bold().textAlign(TextAlign.center).build().text(item),
-                                ],
-                              );
-                            },
-                          ),
-                        );
-                      },
-                    );
-                  },
-                );
-              default:
-                return const SizedBox.shrink();
-            }
+              },
+            );
           },
-          childCount: 2,
         ),
       ),
     );

--- a/lib/features/home/views/regional_exhibition_view.dart
+++ b/lib/features/home/views/regional_exhibition_view.dart
@@ -1,10 +1,13 @@
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
 
 class RegionalExhibitionView extends StatefulWidget {
   const RegionalExhibitionView({super.key});
@@ -30,7 +33,10 @@ class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
                   children: [
                     Padding(
                       padding: EdgeInsets.only(
-                          left: 24.w, right: 24.w, bottom: 12.h),
+                        left: 24.w,
+                        right: 24.w,
+                        bottom: 12.h,
+                      ),
                       child: ArtTripText.pretendard()
                           .title01Bold()
                           .build()
@@ -43,8 +49,8 @@ class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
                         scrollDirection: Axis.horizontal,
                         itemCount: data.length,
                         padding: EdgeInsets.symmetric(horizontal: 24.w),
-                        separatorBuilder: (context, index) =>
-                            SizedBox(width: 8.w),
+                        separatorBuilder:
+                            (context, index) => SizedBox(width: 8.w),
                         itemBuilder: (context, index) {
                           var item = data[index];
                           return Column(
@@ -65,6 +71,57 @@ class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
                       ),
                     ),
                   ],
+                );
+              },
+              onLoading: () {
+                return Shimmer(
+                  duration: const Duration(
+                    milliseconds: AppConsts.shimmerDurationMs,
+                  ),
+                  interval: const Duration(
+                    milliseconds: AppConsts.shimmerIntervalMs,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 12.h,
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 24.w),
+                        child: const ShimmerSkeletonItem(
+                          width: 160,
+                          height: 20,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 90.h,
+                        child: ListView.separated(
+                          physics: const NeverScrollableScrollPhysics(),
+                          shrinkWrap: true,
+                          scrollDirection: Axis.horizontal,
+                          itemCount: 6,
+                          padding: EdgeInsets.symmetric(horizontal: 24.w),
+                          separatorBuilder:
+                              (context, index) => SizedBox(width: 8.w),
+                          itemBuilder: (context, index) {
+                            return Column(
+                              spacing: 12.h,
+                              children: [
+                                const ShimmerSkeletonItem(
+                                  width: 64,
+                                  height: 64,
+                                ),
+                                const ShimmerSkeletonItem(
+                                  width: 21,
+                                  height: 14,
+                                  radius: 8,
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
                 );
               },
             );

--- a/lib/features/home/views/regional_exhibition_view.dart
+++ b/lib/features/home/views/regional_exhibition_view.dart
@@ -51,7 +51,7 @@ class _RegionalExhibitionViewState extends State<RegionalExhibitionView> {
                                     radius: 32.w,
                                     backgroundColor: Colors.black,
                                   ),
-                                  ArtTripText.pretendard().body02Bold().build().text(item),
+                                  ArtTripText.pretendard().body02Bold().textAlign(TextAlign.center).build().text(item),
                                 ],
                               );
                             },

--- a/lib/features/home/views/today_exhibit_recommendation_view.dart
+++ b/lib/features/home/views/today_exhibit_recommendation_view.dart
@@ -29,6 +29,8 @@ class _TodayExhibitRecommendationViewState
           return AsyncView(
             state: state,
             onData: (data) {
+              if (data.isEmpty) return const SizedBox.shrink();
+
               return SizedBox(
                 height: 240.h,
                 child: ListView.separated(
@@ -39,21 +41,19 @@ class _TodayExhibitRecommendationViewState
                   separatorBuilder: (context, index) => SizedBox(width: 8.w),
                   itemBuilder: (context, index) {
                     var item = data[index];
-                    return item.posterUrl?.isNotEmpty == true
-                        ? Selector<HomeViewModel, String>(
-                          selector: (_, vm) => vm.selectedLocation,
-                          builder: (context, selectedLocation, _) {
-                            return TodayExhibitionWidget(
-                              item: item,
-                              isLiked: false,
-                              showCountry:
-                                  selectedLocation == context.l10n.allItems,
-                              onTap: () {},
-                              likeOnTap: () {},
-                            );
-                          },
-                        )
-                        : const SizedBox.shrink();
+                    return Selector<HomeViewModel, String>(
+                      selector: (_, vm) => vm.selectedLocation,
+                      builder: (context, selectedLocation, _) {
+                        return TodayExhibitionWidget(
+                          item: item,
+                          isLiked: false,
+                          showCountry:
+                              selectedLocation == context.l10n.allItems,
+                          onTap: () {},
+                          likeOnTap: () {},
+                        );
+                      },
+                    );
                   },
                 ),
               );

--- a/lib/features/home/views/today_exhibit_recommendation_view.dart
+++ b/lib/features/home/views/today_exhibit_recommendation_view.dart
@@ -1,11 +1,14 @@
+import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/features/home/widgets/today_exhibition_widget.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
 
 class TodayExhibitRecommendationView extends StatefulWidget {
   const TodayExhibitRecommendationView({super.key});
@@ -38,19 +41,48 @@ class _TodayExhibitRecommendationViewState
                     var item = data[index];
                     return item.posterUrl?.isNotEmpty == true
                         ? Selector<HomeViewModel, String>(
-                            selector: (_, vm) => vm.selectedLocation,
-                            builder: (context, selectedLocation, _) {
-                              return TodayExhibitionWidget(
-                                item: item,
-                                isLiked: false,
-                                showCountry:
-                                    selectedLocation == context.l10n.allItems,
-                                onTap: () {},
-                                likeOnTap: () {},
-                              );
-                            })
+                          selector: (_, vm) => vm.selectedLocation,
+                          builder: (context, selectedLocation, _) {
+                            return TodayExhibitionWidget(
+                              item: item,
+                              isLiked: false,
+                              showCountry:
+                                  selectedLocation == context.l10n.allItems,
+                              onTap: () {},
+                              likeOnTap: () {},
+                            );
+                          },
+                        )
                         : const SizedBox.shrink();
                   },
+                ),
+              );
+            },
+            onLoading: () {
+              return Shimmer(
+                duration: const Duration(
+                  milliseconds: AppConsts.shimmerDurationMs,
+                ),
+                interval: const Duration(
+                  milliseconds: AppConsts.shimmerIntervalMs,
+                ),
+                child: SizedBox(
+                  height: 240.h,
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    scrollDirection: Axis.horizontal,
+                    itemCount: 3,
+                    padding: EdgeInsets.symmetric(horizontal: 24.w),
+                    separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                    itemBuilder: (context, index) {
+                      return const ShimmerSkeletonItem(
+                        width: 180,
+                        height: 240,
+                        radius: 8,
+                      );
+                    },
+                  ),
                 ),
               );
             },

--- a/lib/features/home/views/today_exhibit_recommendation_view.dart
+++ b/lib/features/home/views/today_exhibit_recommendation_view.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/features/home/widgets/today_exhibition_widget.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
@@ -10,52 +11,51 @@ class TodayExhibitRecommendationView extends StatefulWidget {
   const TodayExhibitRecommendationView({super.key});
 
   @override
-  State<TodayExhibitRecommendationView> createState() => _TodayExhibitRecommendationViewState();
+  State<TodayExhibitRecommendationView> createState() =>
+      _TodayExhibitRecommendationViewState();
 }
 
-class _TodayExhibitRecommendationViewState extends State<TodayExhibitRecommendationView> {
+class _TodayExhibitRecommendationViewState
+    extends State<TodayExhibitRecommendationView> {
   @override
   Widget build(BuildContext context) {
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(
-        (context, index) {
-          switch (index) {
-            case 0:
-              return Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
-                selector: (_, vm) => vm.todayExhibitRecommendations,
-                builder: (context, state, _) {
-                  return AsyncView(
-                    state: state,
-                    onData: (data) {
-                      return SizedBox(
-                        height: 240.h,
-                        child: ListView.separated(
-                          shrinkWrap: true,
-                          scrollDirection: Axis.horizontal,
-                          itemCount: data.length,
-                          padding: EdgeInsets.symmetric(horizontal: 24.w),
-                          separatorBuilder: (context, index) => SizedBox(width: 8.w),
-                          itemBuilder: (context, index) {
-                            var item = data[index];
-                            return item.posterUrl?.isNotEmpty == true
-                                ? TodayExhibitionWidget(
-                                    item: item,
-                                    onTap: () {},
-                                    likeOnTap: () {},
-                                  )
-                                : const SizedBox.shrink();
-                          },
-                        ),
-                      );
-                    },
-                  );
-                },
+    return SliverToBoxAdapter(
+      child: Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
+        selector: (_, vm) => vm.todayExhibitRecommendations,
+        builder: (context, state, _) {
+          return AsyncView(
+            state: state,
+            onData: (data) {
+              return SizedBox(
+                height: 240.h,
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  scrollDirection: Axis.horizontal,
+                  itemCount: data.length,
+                  padding: EdgeInsets.symmetric(horizontal: 24.w),
+                  separatorBuilder: (context, index) => SizedBox(width: 8.w),
+                  itemBuilder: (context, index) {
+                    var item = data[index];
+                    return item.posterUrl?.isNotEmpty == true
+                        ? Selector<HomeViewModel, String>(
+                            selector: (_, vm) => vm.selectedLocation,
+                            builder: (context, selectedLocation, _) {
+                              return TodayExhibitionWidget(
+                                item: item,
+                                isLiked: false,
+                                showCountry:
+                                    selectedLocation == context.l10n.allItems,
+                                onTap: () {},
+                                likeOnTap: () {},
+                              );
+                            })
+                        : const SizedBox.shrink();
+                  },
+                ),
               );
-            default:
-              return const SizedBox.shrink();
-          }
+            },
+          );
         },
-        childCount: 1,
       ),
     );
   }

--- a/lib/features/home/views/weekly_exhibition_schedule_view.dart
+++ b/lib/features/home/views/weekly_exhibition_schedule_view.dart
@@ -1,0 +1,236 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item_skeleton.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
+
+class WeeklyExhibitionScheduleView extends StatefulWidget {
+  const WeeklyExhibitionScheduleView({super.key});
+
+  @override
+  State<WeeklyExhibitionScheduleView> createState() =>
+      _WeeklyExhibitionScheduleViewState();
+}
+
+class _WeeklyExhibitionScheduleViewState
+    extends State<WeeklyExhibitionScheduleView> {
+  @override
+  Widget build(BuildContext context) {
+    return Selector<HomeViewModel, AsyncState<List<DateTime>>>(
+      selector: (_, vm) => vm.weeklyCalendar,
+      builder: (context, state, _) {
+        return AsyncView(
+          state: state,
+          isSliverWidget: true,
+          onData: (currentWeek) {
+            return SliverPadding(
+              padding: EdgeInsets.only(left: 24.w, top: 32.h, right: 24.w),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  _buildHeader(),
+                  _buildWeeklyCalendar(currentWeek),
+                  Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
+                    selector: (_, vm) => vm.weeklyExhibitionsBySelectedDate,
+                    builder: (context, state, _) {
+                      return AsyncView(
+                        state: state,
+                        onData: (data) {
+                          // TODO: 빈값 수정 예정
+                          if (data.isEmpty) return const SizedBox.shrink();
+
+                          return Column(
+                            spacing: 8.h,
+                            children: List.generate(data.length, (index) {
+                              return ExhibitionListItem(item: data[index]);
+                            }),
+                          );
+                        },
+                        onLoading: () {
+                          return Shimmer(
+                            duration: const Duration(
+                              milliseconds: AppConsts.shimmerDurationMs,
+                            ),
+                            interval: const Duration(
+                              milliseconds: AppConsts.shimmerIntervalMs,
+                            ),
+                            child: Column(
+                              children: [
+                                const ExhibitionListItemSkeleton(),
+                                SizedBox(height: 8.h),
+                                const ExhibitionListItemSkeleton(),
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ]),
+              ),
+            );
+          },
+          onLoading: () => _buildFullLoading(),
+        );
+      },
+    );
+  }
+
+  GestureDetector _buildHeader() {
+    return GestureDetector(
+      onTap: () {},
+      child: ColoredBox(
+        color: Colors.transparent,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ArtTripText.pretendard().title01Bold().build().text(
+              context.l10n.weeklyExhibitionSchedule,
+            ),
+            SvgPicture.asset(
+              AppAssets.icNoArrowRight,
+              width: 24.w,
+              height: 24.w,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Padding _buildWeeklyCalendar(List<DateTime> currentWeek) {
+    var locale = Localizations.localeOf(context);
+
+    return Padding(
+      padding: EdgeInsetsGeometry.only(top: 8.h, bottom: 20.h),
+      child: SizedBox(
+        height: 50.h,
+        child: Selector<HomeViewModel, DateTime>(
+          selector: (_, vm) => vm.selectedDateInWeek,
+          builder: (context, selectedDateInWeek, _) {
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: List.generate(currentWeek.length, (index) {
+                var date = currentWeek[index];
+                var isToday = DateUtils.isSameDay(date, selectedDateInWeek);
+                var weekDay = AppUtil.weekdayLabel(date: date, locale: locale);
+                return GestureDetector(
+                  onTap: () {
+                    var homeViewModel = Provider.of<HomeViewModel>(
+                      context,
+                      listen: false,
+                    );
+                    homeViewModel.updateSelectedDateInWeek(date);
+                  },
+                  child: Container(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 1.w,
+                      vertical: 1.h,
+                    ),
+                    color: Colors.transparent,
+                    child: Column(
+                      spacing: 4.h,
+                      children: [
+                        Container(
+                          width: 28.w,
+                          height: 28.w,
+                          alignment: Alignment.center,
+                          decoration:
+                              isToday
+                                  ? const BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: AppColors.textPoint,
+                                  )
+                                  : null,
+                          child:
+                              isToday
+                                  ? ArtTripText.pretendard()
+                                      .body01Bold()
+                                      .color(AppColors.textWhite)
+                                      .build()
+                                      .text(date.day.toString())
+                                  : ArtTripText.pretendard()
+                                      .body01Regular()
+                                      .textAlign(TextAlign.center)
+                                      .build()
+                                      .text(date.day.toString()),
+                        ),
+                        isToday
+                            ? ArtTripText.pretendard()
+                                .body01Bold()
+                                .color(AppColors.textPoint)
+                                .textAlign(TextAlign.center)
+                                .build()
+                                .text(weekDay)
+                            : ArtTripText.pretendard()
+                                .body01Light()
+                                .textAlign(TextAlign.center)
+                                .build()
+                                .text(weekDay),
+                      ],
+                    ),
+                  ),
+                );
+              }),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  SliverToBoxAdapter _buildFullLoading() {
+    return SliverToBoxAdapter(
+      child: Shimmer(
+        duration: const Duration(milliseconds: AppConsts.shimmerDurationMs),
+        interval: const Duration(milliseconds: AppConsts.shimmerIntervalMs),
+        child: Padding(
+          padding: EdgeInsets.only(left: 24.w, top: 32.h, right: 24.w),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const ShimmerSkeletonItem(width: 160, height: 20),
+                  SvgPicture.asset(
+                    AppAssets.icNoArrowRight,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ],
+              ),
+              SizedBox(height: 8.h),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(7, (index) {
+                  return Column(
+                    spacing: 4.h,
+                    children: [
+                      const ShimmerSkeletonItem(width: 28, height: 28),
+                      const ShimmerSkeletonItem(width: 16, height: 16),
+                    ],
+                  );
+                }),
+              ),
+              SizedBox(height: 20.h),
+              const ExhibitionListItemSkeleton(),
+              SizedBox(height: 8.h),
+              const ExhibitionListItemSkeleton(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -108,7 +108,7 @@ class TodayExhibitionWidget extends StatelessWidget {
             Container(
               width: 180.w,
               padding: EdgeInsets.all(10.w),
-              alignment: Alignment.bottomCenter,
+              alignment: Alignment.bottomLeft,
               child: Wrap(
                 runSpacing: 4.h,
                 children: [

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -32,12 +32,14 @@ class TodayExhibitionWidget extends StatelessWidget {
         child: Stack(
           children: [
             /// 백그라운드 이미지
-            CachedNetworkImage(
-              imageUrl: item.posterUrl!,
-              width: 180.w,
-              height: 240.h,
-              fit: BoxFit.cover,
-            ),
+            item.posterUrl?.isNotEmpty == true
+                ? CachedNetworkImage(
+                  imageUrl: item.posterUrl!,
+                  width: 180.w,
+                  height: 240.h,
+                  fit: BoxFit.cover,
+                )
+                : const SizedBox.shrink(),
 
             /// 테두리
             Container(

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -70,16 +70,21 @@ class TodayExhibitionWidget extends StatelessWidget {
             ),
 
             /// 국가
+            // TODO: 수정 예정
             showCountry
                 ? Container(
-                    padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
-                    margin: EdgeInsets.only(left: 10.w, top: 16.h),
-                    decoration: BoxDecoration(
-                      color: AppColors.textPrimary.withValues(alpha: 0.6),
-                      borderRadius: BorderRadius.circular(100),
-                    ),
-                    child: ArtTripText.pretendard().body02Bold().color(AppColors.textWhite).build().text('일본'),
-                  )
+                  padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
+                  margin: EdgeInsets.only(left: 10.w, top: 16.h),
+                  decoration: BoxDecoration(
+                    color: AppColors.textPrimary.withValues(alpha: 0.6),
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                  child: ArtTripText.pretendard()
+                      .body02Bold()
+                      .color(AppColors.textWhite)
+                      .build()
+                      .text('일본'),
+                )
                 : const SizedBox.shrink(),
 
             /// 즐겨찾기
@@ -96,6 +101,8 @@ class TodayExhibitionWidget extends StatelessWidget {
                 ),
               ),
             ),
+
+            /// 전시 정보
             Container(
               width: 180.w,
               padding: EdgeInsets.all(10.w),
@@ -103,9 +110,17 @@ class TodayExhibitionWidget extends StatelessWidget {
               child: Wrap(
                 runSpacing: 4.h,
                 children: [
-                  ArtTripText.pretendard().title02Bold().color(AppColors.textWhite).build().text(item.title ?? ''),
+                  ArtTripText.pretendard()
+                      .title02Bold()
+                      .color(AppColors.textWhite)
+                      .build()
+                      .text(item.title ?? ''),
                   // TODO: 필드값 수정 예정
-                  ArtTripText.pretendard().body02Regular().color(AppColors.textWhite).build().text(item.title ?? ''),
+                  ArtTripText.pretendard()
+                      .body02Regular()
+                      .color(AppColors.textWhite)
+                      .build()
+                      .text(item.title ?? ''),
                   ArtTripText.pretendard()
                       .body02Regular()
                       .color(AppColors.textWhite)
@@ -113,7 +128,7 @@ class TodayExhibitionWidget extends StatelessWidget {
                       .text(item.exhibitPeriod ?? ''),
                 ],
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -12,12 +12,14 @@ class TodayExhibitionWidget extends StatelessWidget {
     super.key,
     required this.item,
     this.isLiked = false,
+    this.showCountry = false,
     this.onTap,
     this.likeOnTap,
   });
 
   final ExhibitModel item;
   final bool isLiked;
+  final bool showCountry;
   final Function()? onTap;
   final Function()? likeOnTap;
 
@@ -68,19 +70,17 @@ class TodayExhibitionWidget extends StatelessWidget {
             ),
 
             /// 국가
-            // Container(
-            //   padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
-            //   margin: EdgeInsets.only(left: 10.w, top: 16.h),
-            //   decoration: BoxDecoration(
-            //     color: AppColors.textPrimary.withValues(alpha: 0.6),
-            //     borderRadius: BorderRadius.circular(100),
-            //   ),
-            //   child: ArtTripText.pretendard()
-            //       .body02Bold()
-            //       .color(AppColors.textWhite)
-            //       .build()
-            //       .text('일본'),
-            // ),
+            showCountry
+                ? Container(
+                    padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
+                    margin: EdgeInsets.only(left: 10.w, top: 16.h),
+                    decoration: BoxDecoration(
+                      color: AppColors.textPrimary.withValues(alpha: 0.6),
+                      borderRadius: BorderRadius.circular(100),
+                    ),
+                    child: ArtTripText.pretendard().body02Bold().color(AppColors.textWhite).build().text('일본'),
+                  )
+                : const SizedBox.shrink(),
 
             /// 즐겨찾기
             // TODO: 즐겨찾기 상태에 따른 아이콘 변경 필요

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -122,7 +122,7 @@ class TodayExhibitionWidget extends StatelessWidget {
                       .body02Regular()
                       .color(AppColors.textWhite)
                       .build()
-                      .text(item.title ?? ''),
+                      .text(item.hallName ?? ''),
                   ArtTripText.pretendard()
                       .body02Regular()
                       .color(AppColors.textWhite)

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -37,6 +37,16 @@ class TodayExhibitionWidget extends StatelessWidget {
               fit: BoxFit.cover,
             ),
 
+            /// 테두리
+            Container(
+              width: 180.w,
+              height: 240.h,
+              decoration: BoxDecoration(
+                border: Border.all(color: AppColors.gray50),
+                borderRadius: BorderRadius.circular(8.r),
+              ),
+            ),
+
             /// 그라데이션 오버레이
             Align(
               alignment: Alignment.bottomCenter,

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -21,6 +21,7 @@
   "regionalExhibition": "지역별 전시",
   "recommendedGenreExhibition": "장르별 전시 추천",
   "ongoing": "진행중",
-  "closingSoon": "마감임박",
-  "upcoming": "진행예정"
+  "endingSoon": "마감임박",
+  "upcoming": "진행예정",
+  "personalizedRecommendationTitle": "{userName}님을 위한 추천"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -18,5 +18,6 @@
   "domesticExhibition": "국내전시",
   "internationalExhibition": "해외전시",
   "allItems": "전체",
-  "regionalExhibition": "지역별 전시"
+  "regionalExhibition": "지역별 전시",
+  "recommendedGenreExhibition": "장르별 전시 추천"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -20,8 +20,9 @@
   "allItems": "전체",
   "regionalExhibition": "지역별 전시",
   "recommendedGenreExhibition": "장르별 전시 추천",
-  "ongoing": "진행중",
+  "onGoing": "진행중",
   "endingSoon": "마감임박",
-  "upcoming": "진행예정",
-  "personalizedRecommendationTitle": "{userName}님을 위한 추천"
+  "upcoming": "전시예정",
+  "personalizedRecommendationTitle": "{userName}님을 위한 추천",
+  "weeklyExhibitionSchedule": "이번주 전시 일정"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -19,5 +19,8 @@
   "internationalExhibition": "해외전시",
   "allItems": "전체",
   "regionalExhibition": "지역별 전시",
-  "recommendedGenreExhibition": "장르별 전시 추천"
+  "recommendedGenreExhibition": "장르별 전시 추천",
+  "ongoing": "진행중",
+  "closingSoon": "마감임박",
+  "upcoming": "진행예정"
 }

--- a/lib/shared/models/exhibit_model.dart
+++ b/lib/shared/models/exhibit_model.dart
@@ -13,7 +13,9 @@ abstract class ExhibitModel with _$ExhibitModel {
     String? posterUrl,
     String? status,
     String? exhibitPeriod,
+    String? hallName,
   }) = _ExhibitModel;
 
-  factory ExhibitModel.fromJson(Map<String, dynamic> json) => _$ExhibitModelFromJson(json);
+  factory ExhibitModel.fromJson(Map<String, dynamic> json) =>
+      _$ExhibitModelFromJson(json);
 }

--- a/lib/shared/utils/snackbar_utils.dart
+++ b/lib/shared/utils/snackbar_utils.dart
@@ -1,13 +1,9 @@
 import 'package:arttrip/core/app_colors.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 /// SnackBar 타입
-enum SnackBarType {
-  success,
-  error,
-  warning,
-  info,
-}
+enum SnackBarType { success, error, warning, info }
 
 /// 공용 SnackBar 유틸리티
 class SnackBarUtils {
@@ -176,10 +172,13 @@ class SnackBarUtils {
       backgroundColor: backgroundColor,
       duration: duration,
       behavior: behavior,
-      margin: margin ?? const EdgeInsets.all(16),
-      padding: padding ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      margin: margin ?? EdgeInsets.all(16.w),
+      padding:
+          padding ?? EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
       elevation: elevation ?? 4,
-      shape: shape ?? RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      shape:
+          shape ??
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.r)),
       action: action,
     );
 

--- a/lib/shared/widgets/async_view.dart
+++ b/lib/shared/widgets/async_view.dart
@@ -10,22 +10,39 @@ class AsyncView<T> extends StatelessWidget {
     required this.onData,
     this.onLoading,
     this.onError,
+    this.isSliverWidget = false,
   });
 
   final AsyncState<T> state;
   final Widget Function(T data) onData;
   final Widget Function()? onLoading;
   final Widget Function({Object? error})? onError;
+  final bool isSliverWidget;
 
   @override
   Widget build(BuildContext context) {
     switch (state.status) {
       case AsyncStatus.loading:
-        return onLoading?.call() ?? const Center(child: CircularProgressIndicator());
+        return onLoading?.call() ??
+            (isSliverWidget
+                ? const SliverToBoxAdapter(
+                  child: Center(child: CircularProgressIndicator()),
+                )
+                : const Center(child: CircularProgressIndicator()));
       case AsyncStatus.error:
         AppUtil.debugLog('AsyncView Error: ${state.error}');
         return onError?.call(error: state.error) ??
-            const Text('Something went wrong', style: TextStyle(color: AppColors.textPrimary));
+            (isSliverWidget
+                ? const SliverToBoxAdapter(
+                  child: Text(
+                    'Something went wrong',
+                    style: TextStyle(color: AppColors.textPrimary),
+                  ),
+                )
+                : const Text(
+                  'Something went wrong',
+                  style: TextStyle(color: AppColors.textPrimary),
+                ));
       case AsyncStatus.success:
         return onData(state.data as T);
     }
@@ -33,14 +50,12 @@ class AsyncView<T> extends StatelessWidget {
 }
 
 class AsyncState<T> {
-  const AsyncState._({
-    required this.status,
-    this.data,
-    this.error,
-  });
+  const AsyncState._({required this.status, this.data, this.error});
   const AsyncState.loading() : this._(status: AsyncStatus.loading);
-  const AsyncState.success(T data) : this._(status: AsyncStatus.success, data: data);
-  const AsyncState.error({Object? error}) : this._(status: AsyncStatus.error, error: error);
+  const AsyncState.success(T data)
+    : this._(status: AsyncStatus.success, data: data);
+  const AsyncState.error({Object? error})
+    : this._(status: AsyncStatus.error, error: error);
 
   final AsyncStatus status;
   final T? data;

--- a/lib/shared/widgets/exhibition_list_item.dart
+++ b/lib/shared/widgets/exhibition_list_item.dart
@@ -66,8 +66,8 @@ class ExhibitionListItem extends StatelessWidget {
                   child: ArtTripText.pretendard().body02Bold().build().text(
                     item.status == 'ONGOING'
                         ? context.l10n.ongoing
-                        : item.status == 'CLOSING_SOON'
-                        ? context.l10n.closingSoon
+                        : item.status == 'ENDING_SOON'
+                        ? context.l10n.endingSoon
                         : context.l10n.upcoming,
                   ),
                 ),

--- a/lib/shared/widgets/exhibition_list_item.dart
+++ b/lib/shared/widgets/exhibition_list_item.dart
@@ -24,113 +24,124 @@ class ExhibitionListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      spacing: 12.w,
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadiusGeometry.circular(8.r),
-          child: Stack(
-            children: [
-              /// 전시 이미지
-              item.posterUrl?.isNotEmpty == true
-                  ? CachedNetworkImage(
-                    imageUrl: item.posterUrl!,
-                    width: 100.w,
-                    height: 100.w,
-                    fit: BoxFit.cover,
-                  )
-                  : const SizedBox.shrink(),
-
-              /// 전시 상태
-              Positioned(
-                right: 0,
-                bottom: 0,
-                child: Container(
-                  padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.only(
-                      topLeft: Radius.circular(16.r),
-                      bottomRight: Radius.circular(16.r),
-                    ),
-                    border: const Border(
-                      right: BorderSide(color: AppColors.gray50),
-                      bottom: BorderSide(color: AppColors.gray50),
-                    ),
-                    color:
-                        item.status == 'ONGOING'
-                            ? AppColors.subLime
-                            : item.status == 'CLOSING_SOON'
-                            ? AppColors.gray0
-                            : AppColors.subRed, // TODO: 색상 확인 필요
-                  ),
-                  child: ArtTripText.pretendard().body02Bold().build().text(
-                    item.status == 'ONGOING'
-                        ? context.l10n.ongoing
-                        : item.status == 'ENDING_SOON'
-                        ? context.l10n.endingSoon
-                        : context.l10n.upcoming,
-                  ),
-                ),
-              ),
-
-              /// 즐겨찾기
-              Positioned(
-                top: 8.h,
-                right: 8.w,
-                child: GestureDetector(
-                  onTap: likeOnTap,
-                  child: SvgPicture.asset(
-                    AppAssets.icLikeCircle(isLiked: isLiked),
-                    width: 24.w,
-                    height: 24.w,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        /// 전시 정보
-        Expanded(
-          child: Column(
-            spacing: 4.h,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '공예',
-                style: TextStyle(
-                  color: AppColors.primary300,
-                  fontSize: 14.sp,
-                  fontFamily: 'Pretendard',
-                  fontWeight: FontWeight.w400,
-                  height: 20 / 14,
-                  letterSpacing: 14 * (-2 / 100),
-                ),
-              ),
-              ArtTripText.pretendard().body01Bold().build().text(
-                item.title ?? '',
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                spacing: 2.h,
+    return GestureDetector(
+      onTap: onTap,
+      child: ColoredBox(
+        color: Colors.transparent,
+        child: Row(
+          spacing: 12.w,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadiusGeometry.circular(8.r),
+              child: Stack(
                 children: [
-                  // TODO: 미술관명 수정 예정
-                  ArtTripText.pretendard()
-                      .body02Regular()
-                      .color(AppColors.textTertiary)
-                      .build()
-                      .text('미술관명'),
-                  ArtTripText.pretendard()
-                      .body02Regular()
-                      .color(AppColors.textTertiary)
-                      .build()
-                      .text(item.exhibitPeriod ?? ''),
+                  /// 전시 이미지
+                  item.posterUrl?.isNotEmpty == true
+                      ? CachedNetworkImage(
+                        imageUrl: item.posterUrl!,
+                        width: 100.w,
+                        height: 100.w,
+                        fit: BoxFit.cover,
+                      )
+                      : const SizedBox.shrink(),
+
+                  /// 전시 상태
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: Container(
+                      padding: EdgeInsets.symmetric(
+                        vertical: 4.h,
+                        horizontal: 8.w,
+                      ),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16.r),
+                        ),
+                        border:
+                            item.status == 'ENDING_SOON'
+                                ? const Border(
+                                  right: BorderSide(color: AppColors.gray50),
+                                  bottom: BorderSide(color: AppColors.gray50),
+                                )
+                                : null,
+                        color:
+                            item.status == 'ONGOING'
+                                ? AppColors.subLime
+                                : item.status == 'ENDING_SOON'
+                                ? AppColors.gray0
+                                : AppColors.subRed, // TODO: 색상 확인 필요
+                      ),
+                      child: ArtTripText.pretendard().body02Bold().build().text(
+                        item.status == 'ONGOING'
+                            ? context.l10n.ongoing
+                            : item.status == 'ENDING_SOON'
+                            ? context.l10n.endingSoon
+                            : context.l10n.upcoming,
+                      ),
+                    ),
+                  ),
+
+                  /// 즐겨찾기
+                  Positioned(
+                    top: 8.h,
+                    right: 8.w,
+                    child: GestureDetector(
+                      onTap: likeOnTap,
+                      child: SvgPicture.asset(
+                        AppAssets.icLikeCircle(isLiked: isLiked),
+                        width: 24.w,
+                        height: 24.w,
+                      ),
+                    ),
+                  ),
                 ],
               ),
-            ],
-          ),
+            ),
+
+            /// 전시 정보
+            Expanded(
+              child: Column(
+                spacing: 4.h,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '공예',
+                    style: TextStyle(
+                      color: AppColors.primary300,
+                      fontSize: 14.sp,
+                      fontFamily: 'Pretendard',
+                      fontWeight: FontWeight.w400,
+                      height: 20 / 14,
+                      letterSpacing: 14 * (-2 / 100),
+                    ),
+                  ),
+                  ArtTripText.pretendard().body01Bold().build().text(
+                    item.title ?? '',
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 2.h,
+                    children: [
+                      // TODO: 미술관명 수정 예정
+                      ArtTripText.pretendard()
+                          .body02Regular()
+                          .color(AppColors.textTertiary)
+                          .build()
+                          .text('미술관명'),
+                      ArtTripText.pretendard()
+                          .body02Regular()
+                          .color(AppColors.textTertiary)
+                          .build()
+                          .text(item.exhibitPeriod ?? ''),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/shared/widgets/exhibition_list_item.dart
+++ b/lib/shared/widgets/exhibition_list_item.dart
@@ -1,8 +1,8 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
-import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/exhibition_status_badge.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -46,41 +46,13 @@ class ExhibitionListItem extends StatelessWidget {
                       : const SizedBox.shrink(),
 
                   /// 전시 상태
-                  Positioned(
-                    right: 0,
-                    bottom: 0,
-                    child: Container(
-                      padding: EdgeInsets.symmetric(
-                        vertical: 4.h,
-                        horizontal: 8.w,
-                      ),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.only(
-                          topLeft: Radius.circular(16.r),
-                        ),
-                        border:
-                            item.status == 'ENDING_SOON'
-                                ? const Border(
-                                  right: BorderSide(color: AppColors.gray50),
-                                  bottom: BorderSide(color: AppColors.gray50),
-                                )
-                                : null,
-                        color:
-                            item.status == 'ONGOING'
-                                ? AppColors.subLime
-                                : item.status == 'ENDING_SOON'
-                                ? AppColors.gray0
-                                : AppColors.subRed, // TODO: 색상 확인 필요
-                      ),
-                      child: ArtTripText.pretendard().body02Bold().build().text(
-                        item.status == 'ONGOING'
-                            ? context.l10n.ongoing
-                            : item.status == 'ENDING_SOON'
-                            ? context.l10n.endingSoon
-                            : context.l10n.upcoming,
-                      ),
-                    ),
-                  ),
+                  item.status != null
+                      ? Positioned(
+                        right: 0,
+                        bottom: 0,
+                        child: ExhibitionStatusBadge(item.status!),
+                      )
+                      : const SizedBox.shrink(),
 
                   /// 즐겨찾기
                   Positioned(

--- a/lib/shared/widgets/exhibition_list_item.dart
+++ b/lib/shared/widgets/exhibition_list_item.dart
@@ -1,0 +1,136 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+
+class ExhibitionListItem extends StatelessWidget {
+  const ExhibitionListItem({
+    super.key,
+    required this.item,
+    this.isLiked = false,
+    this.onTap,
+    this.likeOnTap,
+  });
+
+  final ExhibitModel item;
+  final bool isLiked;
+  final Function()? onTap;
+  final Function()? likeOnTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: 12.w,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadiusGeometry.circular(8.r),
+          child: Stack(
+            children: [
+              /// 전시 이미지
+              item.posterUrl?.isNotEmpty == true
+                  ? CachedNetworkImage(
+                    imageUrl: item.posterUrl!,
+                    width: 100.w,
+                    height: 100.w,
+                    fit: BoxFit.cover,
+                  )
+                  : const SizedBox.shrink(),
+
+              /// 전시 상태
+              Positioned(
+                right: 0,
+                bottom: 0,
+                child: Container(
+                  padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(16.r),
+                      bottomRight: Radius.circular(16.r),
+                    ),
+                    border: const Border(
+                      right: BorderSide(color: AppColors.gray50),
+                      bottom: BorderSide(color: AppColors.gray50),
+                    ),
+                    color:
+                        item.status == 'ONGOING'
+                            ? AppColors.subLime
+                            : item.status == 'CLOSING_SOON'
+                            ? AppColors.gray0
+                            : AppColors.subRed, // TODO: 색상 확인 필요
+                  ),
+                  child: ArtTripText.pretendard().body02Bold().build().text(
+                    item.status == 'ONGOING'
+                        ? context.l10n.ongoing
+                        : item.status == 'CLOSING_SOON'
+                        ? context.l10n.closingSoon
+                        : context.l10n.upcoming,
+                  ),
+                ),
+              ),
+
+              /// 즐겨찾기
+              Positioned(
+                top: 8.h,
+                right: 8.w,
+                child: GestureDetector(
+                  onTap: likeOnTap,
+                  child: SvgPicture.asset(
+                    AppAssets.icLikeCircle(isLiked: isLiked),
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        /// 전시 정보
+        Expanded(
+          child: Column(
+            spacing: 4.h,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '공예',
+                style: TextStyle(
+                  color: AppColors.primary300,
+                  fontSize: 14.sp,
+                  fontFamily: 'Pretendard',
+                  fontWeight: FontWeight.w400,
+                  height: 20 / 14,
+                  letterSpacing: 14 * (-2 / 100),
+                ),
+              ),
+              ArtTripText.pretendard().body01Bold().build().text(
+                item.title ?? '',
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 2.h,
+                children: [
+                  // TODO: 미술관명 수정 예정
+                  ArtTripText.pretendard()
+                      .body02Regular()
+                      .color(AppColors.textTertiary)
+                      .build()
+                      .text('미술관명'),
+                  ArtTripText.pretendard()
+                      .body02Regular()
+                      .color(AppColors.textTertiary)
+                      .build()
+                      .text(item.exhibitPeriod ?? ''),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/shared/widgets/exhibition_list_item_skeleton.dart
+++ b/lib/shared/widgets/exhibition_list_item_skeleton.dart
@@ -1,0 +1,29 @@
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class ExhibitionListItemSkeleton extends StatelessWidget {
+  const ExhibitionListItemSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: 12.w,
+      children: [
+        const ShimmerSkeletonItem(width: 100, height: 100, radius: 8),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const ShimmerSkeletonItem(width: 64, height: 16, radius: 10),
+            SizedBox(height: 4.h),
+            const ShimmerSkeletonItem(width: 160, height: 16, radius: 10),
+            SizedBox(height: 4.h),
+            const ShimmerSkeletonItem(width: 120, height: 14, radius: 10),
+            SizedBox(height: 2.h),
+            const ShimmerSkeletonItem(width: 120, height: 14, radius: 10),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/shared/widgets/exhibition_status_badge.dart
+++ b/lib/shared/widgets/exhibition_status_badge.dart
@@ -1,0 +1,55 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/enum.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class ExhibitionStatusBadge extends StatelessWidget {
+  const ExhibitionStatusBadge(this.status, {super.key});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.only(topLeft: Radius.circular(16.r)),
+        border:
+            status == ExhibitionStatus.endingSoon.status
+                ? const Border(
+                  right: BorderSide(color: AppColors.gray50),
+                  bottom: BorderSide(color: AppColors.gray50),
+                )
+                : status == ExhibitionStatus.upcoming.status
+                ? const Border(
+                  right: BorderSide(color: AppColors.gray100),
+                  bottom: BorderSide(color: AppColors.gray100),
+                )
+                : null,
+        color:
+            status == ExhibitionStatus.onGoing.status
+                ? AppColors.subLime
+                : status == ExhibitionStatus.endingSoon.status
+                ? AppColors.gray0
+                : AppColors.subLightGray,
+      ),
+      child: ArtTripText.pretendard()
+          .body02Bold()
+          .color(
+            status == ExhibitionStatus.upcoming.status
+                ? AppColors.textPoint
+                : AppColors.textPrimary,
+          )
+          .build()
+          .text(
+            status == ExhibitionStatus.onGoing.status
+                ? context.l10n.onGoing
+                : status == ExhibitionStatus.endingSoon.status
+                ? context.l10n.endingSoon
+                : context.l10n.upcoming,
+          ),
+    );
+  }
+}

--- a/lib/shared/widgets/shimmer_skeleton_item.dart
+++ b/lib/shared/widgets/shimmer_skeleton_item.dart
@@ -1,0 +1,32 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// Title 부분에 사용할 때, width: 160, height:20, radius: 100으로 사용합니다.
+class ShimmerSkeletonItem extends StatelessWidget {
+  const ShimmerSkeletonItem({
+    super.key,
+    this.width,
+    this.height,
+    this.radius,
+    this.margin,
+  });
+
+  final double? width;
+  final double? height;
+  final double? radius;
+  final EdgeInsetsGeometry? margin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width?.w,
+      height: height?.h,
+      margin: margin,
+      decoration: BoxDecoration(
+        color: AppColors.gray100,
+        borderRadius: BorderRadius.circular(radius?.r ?? 100),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -861,6 +861,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  shimmer_animation:
+    dependency: "direct main"
+    description:
+      name: shimmer_animation
+      sha256: cc7d80bcb41fba5fbf032f4577ac135928ea1536a06f97053067e6ed7760639d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2+1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   provider: ^6.1.5+1
   json_annotation: ^4.9.0
   cached_network_image: ^3.4.1
+  shimmer_animation: ^2.2.2+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.7.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- 코드 길이 80으로 변경
- 홈 > 장르별 랜덤 전시 목록 API 연동 및 UI 추가
- 홈 > 사용자 맞춤 추천 전시 목록 API 연동 및 UI 추가

하드 코딩 부분은 TODO 로 남겨두었습니다. 
mock데이터 또한 DB 셋업 후 수정 예정입니다.

## Demo
- 장르별 랜덤 전시 목록
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/7fca56b6-8c03-4343-8e87-56a1d21e091c" />

<br><br>

- 사용자 맞춤 추천 전시 목록
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/10275c2d-f228-4dce-aa72-76767bce657a" />

