### PR TITLE
feat: 이번주 전시 일정 UI, 로딩, 뷰 추가, 전시 상태 enum 추가,

### DIFF
--- a/lib/core/app_assets.dart
+++ b/lib/core/app_assets.dart
@@ -14,7 +14,9 @@ class AppAssets {
   static const String icCalendar = 'assets/svg/ic_calendar.svg';
   static const String icSearch = 'assets/svg/ic_search.svg';
   static String icLikeCircle({required bool isLiked}) =>
-      isLiked ? 'assets/svg/ic_like_circle_selected.svg' : 'assets/svg/ic_like_circle_default.svg';
+      isLiked
+          ? 'assets/svg/ic_like_circle_selected.svg'
+          : 'assets/svg/ic_like_circle_default.svg';
   static const String icNoArrowRight = 'assets/svg/ic_no_arrow_right.svg';
 
   // Logo

--- a/lib/core/app_consts.dart
+++ b/lib/core/app_consts.dart
@@ -2,9 +2,12 @@ class AppConsts {
   const AppConsts._();
 
   static const bool useMock = true; // Force using dummy data
-  static const int mockLoadingDelayMillis =
+  static const int mockLoadingDelayMs =
       500; // Dummy data loading delay in milliseconds
 
   static const shimmerDurationMs = 1200;
   static const shimmerIntervalMs = 400;
+
+  static const weekDaysKo = ['일', '월', '화', '수', '목', '금', '토'];
+  static const weekDaysEn = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 }

--- a/lib/core/app_urls.dart
+++ b/lib/core/app_urls.dart
@@ -1,0 +1,6 @@
+class AppUrls {
+  const AppUrls._();
+
+  static const posterUrlMock =
+      'https://velog.velcdn.com/images/hodu_angel/post/f95b3407-6af6-4bf1-8e93-d859b376f175/image.png';
+}

--- a/lib/core/app_utils.dart
+++ b/lib/core/app_utils.dart
@@ -1,3 +1,6 @@
+import 'dart:ui';
+
+import 'package:arttrip/core/app_consts.dart';
 import 'package:flutter/foundation.dart';
 
 class AppUtil {
@@ -5,5 +8,30 @@ class AppUtil {
 
   static void debugLog(str) {
     if (kDebugMode) print('AppLog : $str');
+  }
+
+  /// 이번주의 각 DateTime 리스트
+  static List<DateTime> getCurrentWeek(DateTime focusedDay) {
+    // 일요일 시작
+    var sunday = focusedDay.subtract(Duration(days: focusedDay.weekday % 7));
+    return List.generate(7, (index) => sunday.add(Duration(days: index)));
+  }
+
+  /// 주간 요일
+  static String weekdayLabel({required DateTime date, required Locale locale}) {
+    var isKorean = locale.languageCode == 'ko';
+    var labels = isKorean ? AppConsts.weekDaysKo : AppConsts.weekDaysEn;
+
+    // DateTime.weekday: Mon=1 ... Sun=7
+    return labels[date.weekday % 7];
+  }
+
+  /// '2025-12-25' 포맷 반환
+  static String formatDateYMD(DateTime date) {
+    var year = date.year.toString().padLeft(4, '0');
+    var month = date.month.toString().padLeft(2, '0');
+    var day = date.day.toString().padLeft(2, '0');
+
+    return '$year-$month-$day';
   }
 }

--- a/lib/core/enum.dart
+++ b/lib/core/enum.dart
@@ -6,3 +6,13 @@ enum FontFamilyType {
   const FontFamilyType(this.fontName);
   final String fontName;
 }
+
+enum ExhibitionStatus {
+  upcoming('UPCOMING'), // 예정된 전시
+  onGoing('ONGOING'), // 진행 중인 전시
+  endingSoon('ENDING_SOON'), // 마감 임박(3일전부터)
+  finished('FINISHED'); // 종료된 전시
+
+  const ExhibitionStatus(this.status);
+  final String status;
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -7,6 +7,7 @@ import 'package:arttrip/features/home/views/genre_exhibition_view.dart';
 import 'package:arttrip/features/home/views/personalized_exhibition_view.dart';
 import 'package:arttrip/features/home/views/regional_exhibition_view.dart';
 import 'package:arttrip/features/home/views/today_exhibit_recommendation_view.dart';
+import 'package:arttrip/features/home/views/weekly_exhibition_schedule_view.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -49,6 +50,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             const DomesticOverseasView(),
             const TodayExhibitRecommendationView(),
             const PersonalizedExhibitionView(),
+            const WeeklyExhibitionScheduleView(),
             Selector<HomeViewModel, bool>(
               selector: (_, vm) => vm.isDomestic,
               builder: (context, isDomestic, _) {
@@ -155,6 +157,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             context,
             listen: false,
           );
+          if (index == (homeViewModel.isDomestic ? 1 : 0)) return;
+
           homeViewModel.isDomestic = index == 0 ? false : true;
           homeViewModel.load(context);
         },

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -23,6 +23,12 @@ abstract class HomeRepository {
     String? country,
     String? region,
   });
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  });
 }
 
 class HomeRepositoryImpl implements HomeRepository {
@@ -170,6 +176,37 @@ class HomeRepositoryImpl implements HomeRepository {
           .toList();
     } catch (e) {
       AppUtil.debugLog('fetchPersonalizedExhibitions: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) async {
+    try {
+      var body = {
+        'isDomestic': isDomestic,
+        if (!isDomestic) 'country': country,
+        if (isDomestic) 'region': region,
+        'date': date,
+      };
+      var response = await _dio.post('/home/personalized/random', data: body);
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result is! List) {
+        AppUtil.debugLog(
+          'fetchWeeklyExhibitionsBySelectedDate type inconsistency: ${model.result.runtimeType}',
+        );
+        return null;
+      }
+      return model.result
+          .map<ExhibitModel>((e) => ExhibitModel.fromJson(e))
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchWeeklyExhibitionsBySelectedDate: $e');
     }
     return null;
   }

--- a/lib/features/home/home_repository_hybrid.dart
+++ b/lib/features/home/home_repository_hybrid.dart
@@ -90,4 +90,27 @@ class HomeRepositoryHybrid implements HomeRepository {
       region: region,
     );
   }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) {
+    if (AppConsts.useMock) {
+      return mock.fetchWeeklyExhibitionsBySelectedDate(
+        isDomestic: isDomestic,
+        country: country,
+        region: region,
+        date: date,
+      );
+    }
+    return api.fetchWeeklyExhibitionsBySelectedDate(
+      isDomestic: isDomestic,
+      country: country,
+      region: region,
+      date: date,
+    );
+  }
 }

--- a/lib/features/home/home_repository_mock.dart
+++ b/lib/features/home/home_repository_mock.dart
@@ -1,4 +1,5 @@
 import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/app_urls.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 
@@ -8,7 +9,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchOverseasCountries() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     ); // 실제 딜레이 흉내
     return ['프랑스', '오스트리아', '중국', '일본', '독일', '대한민국'];
   }
@@ -16,7 +17,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchDomesticRegions() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return ['서울', '경기', '충청', '강원', '전라', '경상', '제주'];
   }
@@ -28,24 +29,24 @@ class HomeRepositoryMockImpl implements HomeRepository {
     String? region,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }
@@ -53,7 +54,7 @@ class HomeRepositoryMockImpl implements HomeRepository {
   @override
   Future<List<String>?> fetchGenres() async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
     return [
       '공예',
@@ -78,25 +79,24 @@ class HomeRepositoryMockImpl implements HomeRepository {
     required String genre,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
-    // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }
@@ -108,25 +108,54 @@ class HomeRepositoryMockImpl implements HomeRepository {
     String? region,
   }) async {
     await Future.delayed(
-      const Duration(milliseconds: AppConsts.mockLoadingDelayMillis),
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
     );
-    // TODO: 실데이터 값으로 변경 예정
     return [
       ExhibitModel(
         exhibitId: 13,
         title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/3b368dcf-7_ego.png',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'ONGOING',
-        exhibitPeriod: '2025-12-14 ~ 2025-12-27',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
       ExhibitModel(
         exhibitId: 12,
         title: '눈이 타오르는 비탈',
-        posterUrl:
-            'https://arttrip.s3.ap-northeast-2.amazonaws.com/15e68d85-1_1765512462903.jpg',
+        posterUrl: AppUrls.posterUrlMock,
         status: 'FINISHED',
-        exhibitPeriod: '2025-12-13 ~ 2025-12-14',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
+      ),
+    ];
+  }
+
+  @override
+  Future<List<ExhibitModel>?> fetchWeeklyExhibitionsBySelectedDate({
+    required bool isDomestic,
+    String? country,
+    String? region,
+    required String date,
+  }) async {
+    await Future.delayed(
+      const Duration(milliseconds: AppConsts.mockLoadingDelayMs),
+    );
+    return [
+      ExhibitModel(
+        exhibitId: 13,
+        title: '릴리킴 개인전 《 Ego Travla - between the Seen and the Unseen 》',
+        posterUrl: AppUrls.posterUrlMock,
+        status: 'ONGOING',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
+      ),
+      ExhibitModel(
+        exhibitId: 12,
+        title: '눈이 타오르는 비탈',
+        posterUrl: AppUrls.posterUrlMock,
+        status: 'FINISHED',
+        exhibitPeriod: '2025.12.14 - 2025.12.27',
+        hallName: '프리미엄 월넛홀',
       ),
     ];
   }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/core/app_utils.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/home/home_repository.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
@@ -16,14 +17,20 @@ class HomeViewModel with ChangeNotifier {
       const AsyncState.loading();
   AsyncState<List<ExhibitModel>> personalizedExhibitions =
       const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> weeklyExhibitionsBySelectedDate =
+      const AsyncState.loading();
+  AsyncState<List<DateTime>> weeklyCalendar = const AsyncState.loading();
 
+  final DateTime _today = DateTime.now();
   bool _isDomestic = false;
   late String _selectedLocation;
   late String _selectedGenre;
+  DateTime _selectedDateInWeek = DateTime.now();
 
   bool get isDomestic => _isDomestic;
   String get selectedLocation => _selectedLocation;
   String get selectedGenre => _selectedGenre;
+  DateTime get selectedDateInWeek => _selectedDateInWeek;
 
   set isDomestic(bool value) {
     _isDomestic = value;
@@ -40,12 +47,19 @@ class HomeViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  set selectedDateInWeek(DateTime date) {
+    _selectedDateInWeek = date;
+    notifyListeners();
+  }
+
   void _resetToLoading({bool resetLocations = true}) {
     if (resetLocations) locations = const AsyncState.loading();
     todayExhibitRecommendations = const AsyncState.loading();
     genres = const AsyncState.loading();
     exhibitionsByGenre = const AsyncState.loading();
     personalizedExhibitions = const AsyncState.loading();
+    weeklyExhibitionsBySelectedDate = const AsyncState.loading();
+    weeklyCalendar = const AsyncState.loading();
     notifyListeners();
   }
 
@@ -56,6 +70,8 @@ class HomeViewModel with ChangeNotifier {
           fetchTodayExhibitRecommendations();
           fetchGenres();
           fetchPersonalizedExhibitions();
+          fetchWeeklyExhibitionsBySelectedDate(_today, isInitialLoad: true);
+          getWeeklyCalendar();
         });
   }
 
@@ -65,6 +81,13 @@ class HomeViewModel with ChangeNotifier {
     fetchTodayExhibitRecommendations();
     fetchGenres();
     fetchPersonalizedExhibitions();
+    fetchWeeklyExhibitionsBySelectedDate(_today, isInitialLoad: true);
+    getWeeklyCalendar();
+  }
+
+  void updateSelectedDateInWeek(DateTime date) {
+    selectedDateInWeek = date;
+    fetchWeeklyExhibitionsBySelectedDate(date);
   }
 
   Future<void> fetchOverseasCountries(BuildContext context) async {
@@ -159,6 +182,39 @@ class HomeViewModel with ChangeNotifier {
     } else {
       personalizedExhibitions = AsyncState.success(result);
     }
+    notifyListeners();
+  }
+
+  Future<void> fetchWeeklyExhibitionsBySelectedDate(
+    DateTime date, {
+    bool isInitialLoad = false,
+  }) async {
+    if (isInitialLoad) _selectedDateInWeek = _today;
+    weeklyExhibitionsBySelectedDate = const AsyncState.loading();
+    notifyListeners();
+
+    var result = await repository.fetchWeeklyExhibitionsBySelectedDate(
+      isDomestic: _isDomestic,
+      country: _isDomestic ? null : _selectedLocation,
+      region: _isDomestic ? _selectedLocation : null,
+      date: AppUtil.formatDateYMD(date),
+    );
+    if (result == null) {
+      weeklyExhibitionsBySelectedDate = const AsyncState.error();
+    } else {
+      weeklyExhibitionsBySelectedDate = AsyncState.success(result);
+    }
+    notifyListeners();
+  }
+
+  Future<void> getWeeklyCalendar() async {
+    weeklyCalendar = const AsyncState.loading();
+    notifyListeners();
+
+    await Future.delayed(const Duration(milliseconds: 500));
+    var result = AppUtil.getCurrentWeek(_today);
+
+    weeklyCalendar = AsyncState.success(result);
     notifyListeners();
   }
 }

--- a/lib/features/home/views/today_exhibit_recommendation_view.dart
+++ b/lib/features/home/views/today_exhibit_recommendation_view.dart
@@ -29,6 +29,8 @@ class _TodayExhibitRecommendationViewState
           return AsyncView(
             state: state,
             onData: (data) {
+              if (data.isEmpty) return const SizedBox.shrink();
+
               return SizedBox(
                 height: 240.h,
                 child: ListView.separated(
@@ -39,21 +41,19 @@ class _TodayExhibitRecommendationViewState
                   separatorBuilder: (context, index) => SizedBox(width: 8.w),
                   itemBuilder: (context, index) {
                     var item = data[index];
-                    return item.posterUrl?.isNotEmpty == true
-                        ? Selector<HomeViewModel, String>(
-                          selector: (_, vm) => vm.selectedLocation,
-                          builder: (context, selectedLocation, _) {
-                            return TodayExhibitionWidget(
-                              item: item,
-                              isLiked: false,
-                              showCountry:
-                                  selectedLocation == context.l10n.allItems,
-                              onTap: () {},
-                              likeOnTap: () {},
-                            );
-                          },
-                        )
-                        : const SizedBox.shrink();
+                    return Selector<HomeViewModel, String>(
+                      selector: (_, vm) => vm.selectedLocation,
+                      builder: (context, selectedLocation, _) {
+                        return TodayExhibitionWidget(
+                          item: item,
+                          isLiked: false,
+                          showCountry:
+                              selectedLocation == context.l10n.allItems,
+                          onTap: () {},
+                          likeOnTap: () {},
+                        );
+                      },
+                    );
                   },
                 ),
               );

--- a/lib/features/home/views/weekly_exhibition_schedule_view.dart
+++ b/lib/features/home/views/weekly_exhibition_schedule_view.dart
@@ -1,0 +1,236 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/models/exhibit_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item.dart';
+import 'package:arttrip/shared/widgets/exhibition_list_item_skeleton.dart';
+import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
+
+class WeeklyExhibitionScheduleView extends StatefulWidget {
+  const WeeklyExhibitionScheduleView({super.key});
+
+  @override
+  State<WeeklyExhibitionScheduleView> createState() =>
+      _WeeklyExhibitionScheduleViewState();
+}
+
+class _WeeklyExhibitionScheduleViewState
+    extends State<WeeklyExhibitionScheduleView> {
+  @override
+  Widget build(BuildContext context) {
+    return Selector<HomeViewModel, AsyncState<List<DateTime>>>(
+      selector: (_, vm) => vm.weeklyCalendar,
+      builder: (context, state, _) {
+        return AsyncView(
+          state: state,
+          isSliverWidget: true,
+          onData: (currentWeek) {
+            return SliverPadding(
+              padding: EdgeInsets.only(left: 24.w, top: 32.h, right: 24.w),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  _buildHeader(),
+                  _buildWeeklyCalendar(currentWeek),
+                  Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
+                    selector: (_, vm) => vm.weeklyExhibitionsBySelectedDate,
+                    builder: (context, state, _) {
+                      return AsyncView(
+                        state: state,
+                        onData: (data) {
+                          // TODO: 빈값 수정 예정
+                          if (data.isEmpty) return const SizedBox.shrink();
+
+                          return Column(
+                            spacing: 8.h,
+                            children: List.generate(data.length, (index) {
+                              return ExhibitionListItem(item: data[index]);
+                            }),
+                          );
+                        },
+                        onLoading: () {
+                          return Shimmer(
+                            duration: const Duration(
+                              milliseconds: AppConsts.shimmerDurationMs,
+                            ),
+                            interval: const Duration(
+                              milliseconds: AppConsts.shimmerIntervalMs,
+                            ),
+                            child: Column(
+                              children: [
+                                const ExhibitionListItemSkeleton(),
+                                SizedBox(height: 8.h),
+                                const ExhibitionListItemSkeleton(),
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ]),
+              ),
+            );
+          },
+          onLoading: () => _buildFullLoading(),
+        );
+      },
+    );
+  }
+
+  GestureDetector _buildHeader() {
+    return GestureDetector(
+      onTap: () {},
+      child: ColoredBox(
+        color: Colors.transparent,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ArtTripText.pretendard().title01Bold().build().text(
+              context.l10n.weeklyExhibitionSchedule,
+            ),
+            SvgPicture.asset(
+              AppAssets.icNoArrowRight,
+              width: 24.w,
+              height: 24.w,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Padding _buildWeeklyCalendar(List<DateTime> currentWeek) {
+    var locale = Localizations.localeOf(context);
+
+    return Padding(
+      padding: EdgeInsetsGeometry.only(top: 8.h, bottom: 20.h),
+      child: SizedBox(
+        height: 50.h,
+        child: Selector<HomeViewModel, DateTime>(
+          selector: (_, vm) => vm.selectedDateInWeek,
+          builder: (context, selectedDateInWeek, _) {
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: List.generate(currentWeek.length, (index) {
+                var date = currentWeek[index];
+                var isToday = DateUtils.isSameDay(date, selectedDateInWeek);
+                var weekDay = AppUtil.weekdayLabel(date: date, locale: locale);
+                return GestureDetector(
+                  onTap: () {
+                    var homeViewModel = Provider.of<HomeViewModel>(
+                      context,
+                      listen: false,
+                    );
+                    homeViewModel.updateSelectedDateInWeek(date);
+                  },
+                  child: Container(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 1.w,
+                      vertical: 1.h,
+                    ),
+                    color: Colors.transparent,
+                    child: Column(
+                      spacing: 4.h,
+                      children: [
+                        Container(
+                          width: 28.w,
+                          height: 28.w,
+                          alignment: Alignment.center,
+                          decoration:
+                              isToday
+                                  ? const BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: AppColors.textPoint,
+                                  )
+                                  : null,
+                          child:
+                              isToday
+                                  ? ArtTripText.pretendard()
+                                      .body01Bold()
+                                      .color(AppColors.textWhite)
+                                      .build()
+                                      .text(date.day.toString())
+                                  : ArtTripText.pretendard()
+                                      .body01Regular()
+                                      .textAlign(TextAlign.center)
+                                      .build()
+                                      .text(date.day.toString()),
+                        ),
+                        isToday
+                            ? ArtTripText.pretendard()
+                                .body01Bold()
+                                .color(AppColors.textPoint)
+                                .textAlign(TextAlign.center)
+                                .build()
+                                .text(weekDay)
+                            : ArtTripText.pretendard()
+                                .body01Light()
+                                .textAlign(TextAlign.center)
+                                .build()
+                                .text(weekDay),
+                      ],
+                    ),
+                  ),
+                );
+              }),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  SliverToBoxAdapter _buildFullLoading() {
+    return SliverToBoxAdapter(
+      child: Shimmer(
+        duration: const Duration(milliseconds: AppConsts.shimmerDurationMs),
+        interval: const Duration(milliseconds: AppConsts.shimmerIntervalMs),
+        child: Padding(
+          padding: EdgeInsets.only(left: 24.w, top: 32.h, right: 24.w),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const ShimmerSkeletonItem(width: 160, height: 20),
+                  SvgPicture.asset(
+                    AppAssets.icNoArrowRight,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ],
+              ),
+              SizedBox(height: 8.h),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(7, (index) {
+                  return Column(
+                    spacing: 4.h,
+                    children: [
+                      const ShimmerSkeletonItem(width: 28, height: 28),
+                      const ShimmerSkeletonItem(width: 16, height: 16),
+                    ],
+                  );
+                }),
+              ),
+              SizedBox(height: 20.h),
+              const ExhibitionListItemSkeleton(),
+              SizedBox(height: 8.h),
+              const ExhibitionListItemSkeleton(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/widgets/today_exhibition_widget.dart
+++ b/lib/features/home/widgets/today_exhibition_widget.dart
@@ -122,7 +122,7 @@ class TodayExhibitionWidget extends StatelessWidget {
                       .body02Regular()
                       .color(AppColors.textWhite)
                       .build()
-                      .text(item.title ?? ''),
+                      .text(item.hallName ?? ''),
                   ArtTripText.pretendard()
                       .body02Regular()
                       .color(AppColors.textWhite)

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -20,8 +20,9 @@
   "allItems": "전체",
   "regionalExhibition": "지역별 전시",
   "recommendedGenreExhibition": "장르별 전시 추천",
-  "ongoing": "진행중",
+  "onGoing": "진행중",
   "endingSoon": "마감임박",
-  "upcoming": "진행예정",
-  "personalizedRecommendationTitle": "{userName}님을 위한 추천"
+  "upcoming": "전시예정",
+  "personalizedRecommendationTitle": "{userName}님을 위한 추천",
+  "weeklyExhibitionSchedule": "이번주 전시 일정"
 }

--- a/lib/shared/models/exhibit_model.dart
+++ b/lib/shared/models/exhibit_model.dart
@@ -13,7 +13,9 @@ abstract class ExhibitModel with _$ExhibitModel {
     String? posterUrl,
     String? status,
     String? exhibitPeriod,
+    String? hallName,
   }) = _ExhibitModel;
 
-  factory ExhibitModel.fromJson(Map<String, dynamic> json) => _$ExhibitModelFromJson(json);
+  factory ExhibitModel.fromJson(Map<String, dynamic> json) =>
+      _$ExhibitModelFromJson(json);
 }

--- a/lib/shared/widgets/async_view.dart
+++ b/lib/shared/widgets/async_view.dart
@@ -10,22 +10,39 @@ class AsyncView<T> extends StatelessWidget {
     required this.onData,
     this.onLoading,
     this.onError,
+    this.isSliverWidget = false,
   });
 
   final AsyncState<T> state;
   final Widget Function(T data) onData;
   final Widget Function()? onLoading;
   final Widget Function({Object? error})? onError;
+  final bool isSliverWidget;
 
   @override
   Widget build(BuildContext context) {
     switch (state.status) {
       case AsyncStatus.loading:
-        return onLoading?.call() ?? const Center(child: CircularProgressIndicator());
+        return onLoading?.call() ??
+            (isSliverWidget
+                ? const SliverToBoxAdapter(
+                  child: Center(child: CircularProgressIndicator()),
+                )
+                : const Center(child: CircularProgressIndicator()));
       case AsyncStatus.error:
         AppUtil.debugLog('AsyncView Error: ${state.error}');
         return onError?.call(error: state.error) ??
-            const Text('Something went wrong', style: TextStyle(color: AppColors.textPrimary));
+            (isSliverWidget
+                ? const SliverToBoxAdapter(
+                  child: Text(
+                    'Something went wrong',
+                    style: TextStyle(color: AppColors.textPrimary),
+                  ),
+                )
+                : const Text(
+                  'Something went wrong',
+                  style: TextStyle(color: AppColors.textPrimary),
+                ));
       case AsyncStatus.success:
         return onData(state.data as T);
     }
@@ -33,14 +50,12 @@ class AsyncView<T> extends StatelessWidget {
 }
 
 class AsyncState<T> {
-  const AsyncState._({
-    required this.status,
-    this.data,
-    this.error,
-  });
+  const AsyncState._({required this.status, this.data, this.error});
   const AsyncState.loading() : this._(status: AsyncStatus.loading);
-  const AsyncState.success(T data) : this._(status: AsyncStatus.success, data: data);
-  const AsyncState.error({Object? error}) : this._(status: AsyncStatus.error, error: error);
+  const AsyncState.success(T data)
+    : this._(status: AsyncStatus.success, data: data);
+  const AsyncState.error({Object? error})
+    : this._(status: AsyncStatus.error, error: error);
 
   final AsyncStatus status;
   final T? data;

--- a/lib/shared/widgets/exhibition_list_item.dart
+++ b/lib/shared/widgets/exhibition_list_item.dart
@@ -1,8 +1,8 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
-import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/shared/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/exhibition_status_badge.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -46,41 +46,13 @@ class ExhibitionListItem extends StatelessWidget {
                       : const SizedBox.shrink(),
 
                   /// 전시 상태
-                  Positioned(
-                    right: 0,
-                    bottom: 0,
-                    child: Container(
-                      padding: EdgeInsets.symmetric(
-                        vertical: 4.h,
-                        horizontal: 8.w,
-                      ),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.only(
-                          topLeft: Radius.circular(16.r),
-                        ),
-                        border:
-                            item.status == 'ENDING_SOON'
-                                ? const Border(
-                                  right: BorderSide(color: AppColors.gray50),
-                                  bottom: BorderSide(color: AppColors.gray50),
-                                )
-                                : null,
-                        color:
-                            item.status == 'ONGOING'
-                                ? AppColors.subLime
-                                : item.status == 'ENDING_SOON'
-                                ? AppColors.gray0
-                                : AppColors.subRed, // TODO: 색상 확인 필요
-                      ),
-                      child: ArtTripText.pretendard().body02Bold().build().text(
-                        item.status == 'ONGOING'
-                            ? context.l10n.ongoing
-                            : item.status == 'ENDING_SOON'
-                            ? context.l10n.endingSoon
-                            : context.l10n.upcoming,
-                      ),
-                    ),
-                  ),
+                  item.status != null
+                      ? Positioned(
+                        right: 0,
+                        bottom: 0,
+                        child: ExhibitionStatusBadge(item.status!),
+                      )
+                      : const SizedBox.shrink(),
 
                   /// 즐겨찾기
                   Positioned(

--- a/lib/shared/widgets/exhibition_status_badge.dart
+++ b/lib/shared/widgets/exhibition_status_badge.dart
@@ -1,0 +1,55 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/enum.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class ExhibitionStatusBadge extends StatelessWidget {
+  const ExhibitionStatusBadge(this.status, {super.key});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 4.h, horizontal: 8.w),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.only(topLeft: Radius.circular(16.r)),
+        border:
+            status == ExhibitionStatus.endingSoon.status
+                ? const Border(
+                  right: BorderSide(color: AppColors.gray50),
+                  bottom: BorderSide(color: AppColors.gray50),
+                )
+                : status == ExhibitionStatus.upcoming.status
+                ? const Border(
+                  right: BorderSide(color: AppColors.gray100),
+                  bottom: BorderSide(color: AppColors.gray100),
+                )
+                : null,
+        color:
+            status == ExhibitionStatus.onGoing.status
+                ? AppColors.subLime
+                : status == ExhibitionStatus.endingSoon.status
+                ? AppColors.gray0
+                : AppColors.subLightGray,
+      ),
+      child: ArtTripText.pretendard()
+          .body02Bold()
+          .color(
+            status == ExhibitionStatus.upcoming.status
+                ? AppColors.textPoint
+                : AppColors.textPrimary,
+          )
+          .build()
+          .text(
+            status == ExhibitionStatus.onGoing.status
+                ? context.l10n.onGoing
+                : status == ExhibitionStatus.endingSoon.status
+                ? context.l10n.endingSoon
+                : context.l10n.upcoming,
+          ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- 오늘의 랜덤 전시 추천 빈값일 경우 공간 확보하던 이슈 수정
- 전시 상태 enum 추가
- 주간 캘린더 추가
- 주간 선택한 일자의 랜덤 전시 리스트 API 연동
- 이번주 전시  주간 캘린더 로딩 뷰 -> 전시 리스트 로딩 뷰 추가
- AsyncView에 isSliverWidget 여부 추가

## Demo
https://github.com/user-attachments/assets/57cefcb4-dfb5-4d6f-886d-c733ef945d97

