### PR TITLE
refactor: 홈 화면 데이터 캐싱처리, 해외전시/국내전시 enum 타입 추가

### DIFF
--- a/assets/svg/ic_close.svg
+++ b/assets/svg/ic_close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 18L18 6" stroke="#111111" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M18 18L6 6" stroke="#111111" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/lib/core/app_assets.dart
+++ b/lib/core/app_assets.dart
@@ -26,6 +26,7 @@ class AppAssets {
   static const String icFilter = 'assets/svg/ic_filter.svg';
   static const String icHeart = 'assets/svg/ic_heart.svg';
   static const String icEmptyHeart = 'assets/svg/ic_empty_heart.svg';
+  static const String icClose = 'assets/svg/ic_close.svg';
 
   // Logo
   static const String icLogoWhite = 'assets/svg/ic_logo_white.svg';

--- a/lib/core/enum.dart
+++ b/lib/core/enum.dart
@@ -16,3 +16,5 @@ enum ExhibitionStatus {
   const ExhibitionStatus(this.status);
   final String status;
 }
+
+enum LocationType { overseas, domestic }

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -58,7 +58,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                   padding: EdgeInsets.only(top: isDomestic ? 16.h : 0),
                   sliver: TodayExhibitsRecommendationView(isDomestic),
                 ),
-                PersonalizedExhibitsView(isDomestic),
+                const PersonalizedExhibitsView(),
                 const WeeklyExhibitsScheduleView(),
                 isDomestic
                     ? const RegionalExhibitsView()

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -42,43 +42,32 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     return Scaffold(
       backgroundColor: AppColors.gray0,
       body: SafeArea(
-        child: CustomScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          controller: _scrollController,
-          slivers: [
-            _buildAppBar(),
-            _buildExhibitTabBar(),
-            Selector<HomeViewModel, bool>(
-              selector: (_, vm) => vm.isDomestic,
-              builder: (context, isDomestic, _) {
-                if (isDomestic) {
-                  return const SliverToBoxAdapter(child: SizedBox.shrink());
-                }
-                return const DomesticOverseasView();
-              },
-            ),
-            Selector<HomeViewModel, bool>(
-              selector: (_, vm) => vm.isDomestic,
-              builder: (context, isDomestic, _) {
-                return SliverPadding(
+        child: Selector<HomeViewModel, bool>(
+          selector: (_, vm) => vm.isDomestic,
+          builder: (context, isDomestic, _) {
+            return CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              controller: _scrollController,
+              slivers: [
+                _buildAppBar(),
+                _buildExhibitTabBar(),
+                isDomestic
+                    ? const SliverToBoxAdapter(child: SizedBox.shrink())
+                    : const DomesticOverseasView(),
+                SliverPadding(
                   padding: EdgeInsets.only(top: isDomestic ? 16.h : 0),
-                  sliver: const TodayExhibitsRecommendationView(),
-                );
-              },
-            ),
-            const PersonalizedExhibitsView(),
-            const WeeklyExhibitsScheduleView(),
-            Selector<HomeViewModel, bool>(
-              selector: (_, vm) => vm.isDomestic,
-              builder: (context, isDomestic, _) {
-                return isDomestic
+                  sliver: TodayExhibitsRecommendationView(isDomestic),
+                ),
+                PersonalizedExhibitsView(isDomestic),
+                const WeeklyExhibitsScheduleView(),
+                isDomestic
                     ? const RegionalExhibitsView()
-                    : const SliverToBoxAdapter(child: SizedBox.shrink());
-              },
-            ),
-            const GenreExhibitsView(),
-            SliverToBoxAdapter(child: SizedBox(height: 24.h)),
-          ],
+                    : const SliverToBoxAdapter(child: SizedBox.shrink()),
+                const GenreExhibitsView(),
+                SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+              ],
+            );
+          },
         ),
       ),
     );
@@ -162,7 +151,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           Tab(text: context.l10n.internationalExhibition),
           Tab(text: context.l10n.domesticExhibition),
         ],
-        onTap: (index) {
+        onTap: (index) async {
           var homeViewModel = Provider.of<HomeViewModel>(
             context,
             listen: false,
@@ -170,7 +159,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           if (index == (homeViewModel.isDomestic ? 1 : 0)) return;
 
           homeViewModel.isDomestic = index == 0 ? false : true;
-          homeViewModel.load(context);
+          await homeViewModel.load(context);
         },
       ),
     );

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/enum.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/exhibit/viewmodel/exhibit_viewmodel.dart';
@@ -11,16 +14,29 @@ class HomeViewModel with ChangeNotifier {
   final ExhibitViewModel exhibitVM;
   final HomeRepository homeRepository;
 
-  AsyncState<List<String>> locations = const AsyncState.loading();
+  AsyncState<List<String>> overseasCountries = const AsyncState.loading();
+  AsyncState<List<String>> domesticRegions = const AsyncState.loading();
   AsyncState<List<ExhibitModel>> todayExhibitRecommendations =
       const AsyncState.loading();
   AsyncState<List<String>> genres = const AsyncState.loading();
   AsyncState<List<ExhibitModel>> exhibitsByGenre = const AsyncState.loading();
-  AsyncState<List<ExhibitModel>> personalizedExhibits =
-      const AsyncState.loading();
-  AsyncState<List<ExhibitModel>> weeklyExhibitsBySelectedDate =
-      const AsyncState.loading();
+  Map<String, AsyncState<List<ExhibitModel>>> personalizedExhibits = {
+    LocationType.overseas.name: const AsyncState.loading(),
+    LocationType.domestic.name: const AsyncState.loading(),
+  };
+  Map<String, AsyncState<List<ExhibitModel>>> weeklyExhibitsBySelectedDate = {
+    DateTime.now().day.toString(): const AsyncState.loading(),
+  };
   AsyncState<List<DateTime>> weeklyCalendar = const AsyncState.loading();
+
+  List<String>? _overseasCountriesCache;
+  List<String>? _domesticRegionsCache;
+  final Map<String, List<ExhibitModel>> _todayExhibitRecommendationsCache = {};
+  final Map<String, List<ExhibitModel>> _personalizedExhibitsCache = {};
+  List<DateTime>? _weeklyCalendarCache;
+  final Map<String, List<ExhibitModel>> _weeklyExhibitsBySelectedDateCache = {};
+  List<String>? _genresCache;
+  final Map<String, List<ExhibitModel>> _exhibitsByGenreCache = {};
 
   final DateTime _today = DateTime.now();
   bool _isDomestic = false;
@@ -54,31 +70,36 @@ class HomeViewModel with ChangeNotifier {
   }
 
   void _resetToLoading({bool resetLocations = true}) {
-    if (resetLocations) locations = const AsyncState.loading();
+    if (resetLocations) overseasCountries = const AsyncState.loading();
     todayExhibitRecommendations = const AsyncState.loading();
     genres = const AsyncState.loading();
     exhibitsByGenre = const AsyncState.loading();
-    personalizedExhibits = const AsyncState.loading();
-    weeklyExhibitsBySelectedDate = const AsyncState.loading();
+    personalizedExhibits = {
+      LocationType.overseas.name: const AsyncState.loading(),
+      LocationType.domestic.name: const AsyncState.loading(),
+    };
+    weeklyExhibitsBySelectedDate[_today.day.toString()] =
+        const AsyncState.loading();
     weeklyCalendar = const AsyncState.loading();
     notifyListeners();
   }
 
-  void load(BuildContext context) {
-    _resetToLoading();
-    (_isDomestic ? fetchDomesticRegions() : fetchOverseasCountries(context))
-        .then((_) {
-          fetchTodayExhibitRecommendations();
-          fetchGenres();
-          fetchPersonalizedExhibits();
-          fetchWeeklyExhibitsBySelectedDate(_today, isInitialLoad: true);
-          getWeeklyCalendar();
-        });
+  Future<void> load(BuildContext context, {bool refresh = false}) async {
+    if (refresh) _resetToLoading();
+    await (_isDomestic
+        ? fetchDomesticRegions()
+        : fetchOverseasCountries(context));
+
+    unawaited(fetchTodayExhibitRecommendations());
+    unawaited(fetchGenres());
+    unawaited(fetchPersonalizedExhibits());
+    unawaited(fetchWeeklyExhibitsBySelectedDate(_today, isInitialLoad: true));
+    unawaited(getWeeklyCalendar());
   }
 
   void updateSelectedLocation(String location) {
     _selectedLocation = location;
-    _resetToLoading(resetLocations: false);
+    // _resetToLoading(resetLocations: false);
     fetchTodayExhibitRecommendations();
     fetchGenres();
     fetchPersonalizedExhibits();
@@ -92,52 +113,83 @@ class HomeViewModel with ChangeNotifier {
   }
 
   Future<void> fetchOverseasCountries(BuildContext context) async {
-    locations = const AsyncState.loading();
+    if (_overseasCountriesCache != null) {
+      _selectedLocation = context.l10n.allItems;
+      overseasCountries = AsyncState.success(_overseasCountriesCache!);
+      notifyListeners();
+      return;
+    }
+
+    overseasCountries = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchOverseasCountries();
     if (result == null || context.mounted == false) {
-      locations = const AsyncState.error();
+      overseasCountries = const AsyncState.error();
     } else {
       result = [context.l10n.allItems, ...result];
       _selectedLocation = context.l10n.allItems;
-      locations = AsyncState.success(result);
+      overseasCountries = AsyncState.success(result);
+      _overseasCountriesCache = result;
     }
     notifyListeners();
   }
 
   Future<void> fetchDomesticRegions() async {
-    locations = const AsyncState.loading();
+    if (_domesticRegionsCache != null) {
+      domesticRegions = AsyncState.success(_domesticRegionsCache!);
+      notifyListeners();
+      return;
+    }
+
+    domesticRegions = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchDomesticRegions();
     if (result == null) {
-      locations = const AsyncState.error();
+      domesticRegions = const AsyncState.error();
     } else {
-      if (result.isNotEmpty) _selectedLocation = result[0];
-      locations = AsyncState.success(result);
+      domesticRegions = AsyncState.success(result);
+      _domesticRegionsCache = result;
     }
     notifyListeners();
   }
 
   Future<void> fetchTodayExhibitRecommendations() async {
+    var key = _isDomestic ? LocationType.domestic.name : _selectedLocation;
+    if (_todayExhibitRecommendationsCache[key] != null) {
+      todayExhibitRecommendations = AsyncState.success(
+        _todayExhibitRecommendationsCache[_selectedLocation]!,
+      );
+      notifyListeners();
+      return;
+    }
+
     todayExhibitRecommendations = const AsyncState.loading();
     notifyListeners();
+
     var result = await homeRepository.fetchTodayExhibitRecommendations(
       isDomestic: _isDomestic,
       country: _isDomestic ? null : _selectedLocation,
-      region: _isDomestic ? _selectedLocation : null,
+      region: _isDomestic ? '전체' : null,
     );
     if (result == null) {
       todayExhibitRecommendations = const AsyncState.error();
     } else {
       exhibitVM.initializeFromExhibits(result);
       todayExhibitRecommendations = AsyncState.success(result);
+      _todayExhibitRecommendationsCache[key] = result;
     }
     notifyListeners();
   }
 
   Future<void> fetchGenres() async {
+    if (_genresCache != null) {
+      _selectedGenre = _genresCache!.first;
+      genres = AsyncState.success(_genresCache!);
+      notifyListeners();
+      return;
+    }
     genres = const AsyncState.loading();
     notifyListeners();
 
@@ -147,12 +199,20 @@ class HomeViewModel with ChangeNotifier {
     } else {
       genres = AsyncState.success(result);
       _selectedGenre = result.first;
+      _genresCache = result;
     }
     notifyListeners();
     await fetchExhibitsByGenre();
   }
 
   Future<void> fetchExhibitsByGenre() async {
+    if (_exhibitsByGenreCache[_selectedGenre] != null) {
+      exhibitsByGenre = AsyncState.success(
+        _exhibitsByGenreCache[_selectedGenre]!,
+      );
+      notifyListeners();
+      return;
+    }
     exhibitsByGenre = const AsyncState.loading();
     notifyListeners();
 
@@ -167,12 +227,21 @@ class HomeViewModel with ChangeNotifier {
     } else {
       exhibitsByGenre = AsyncState.success(result);
       exhibitVM.initializeFromExhibits(result);
+      _exhibitsByGenreCache[_selectedGenre] = result;
     }
     notifyListeners();
   }
 
   Future<void> fetchPersonalizedExhibits() async {
-    personalizedExhibits = const AsyncState.loading();
+    var location = _isDomestic ? LocationType.domestic : LocationType.overseas;
+    var cached = _personalizedExhibitsCache[location.name];
+    if (cached != null) {
+      personalizedExhibits[location.name] = AsyncState.success(cached);
+      notifyListeners();
+      return;
+    }
+
+    personalizedExhibits[location.name] = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchPersonalizedExhibits(
@@ -181,10 +250,11 @@ class HomeViewModel with ChangeNotifier {
       region: _isDomestic ? _selectedLocation : null,
     );
     if (result == null) {
-      personalizedExhibits = const AsyncState.error();
+      personalizedExhibits[location.name] = const AsyncState.error();
     } else {
-      personalizedExhibits = AsyncState.success(result);
+      personalizedExhibits[location.name] = AsyncState.success(result);
       exhibitVM.initializeFromExhibits(result);
+      _personalizedExhibitsCache[location.name] = result;
     }
     notifyListeners();
   }
@@ -194,7 +264,17 @@ class HomeViewModel with ChangeNotifier {
     bool isInitialLoad = false,
   }) async {
     if (isInitialLoad) _selectedDateInWeek = _today;
-    weeklyExhibitsBySelectedDate = const AsyncState.loading();
+    var selectedDateDay = _selectedDateInWeek.day.toString();
+
+    if (_weeklyExhibitsBySelectedDateCache[selectedDateDay] != null) {
+      weeklyExhibitsBySelectedDate[selectedDateDay] = AsyncState.success(
+        _weeklyExhibitsBySelectedDateCache[selectedDateDay]!,
+      );
+      notifyListeners();
+      return;
+    }
+
+    weeklyExhibitsBySelectedDate[selectedDateDay] = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchWeeklyExhibitsBySelectedDate(
@@ -204,15 +284,23 @@ class HomeViewModel with ChangeNotifier {
       date: AppUtil.formatDateYMD(date),
     );
     if (result == null) {
-      weeklyExhibitsBySelectedDate = const AsyncState.error();
+      weeklyExhibitsBySelectedDate[selectedDateDay] = const AsyncState.error();
     } else {
-      weeklyExhibitsBySelectedDate = AsyncState.success(result);
+      weeklyExhibitsBySelectedDate[selectedDateDay] = AsyncState.success(
+        result,
+      );
       exhibitVM.initializeFromExhibits(result);
+      _weeklyExhibitsBySelectedDateCache[selectedDateDay] = result;
     }
     notifyListeners();
   }
 
   Future<void> getWeeklyCalendar() async {
+    if (_weeklyCalendarCache != null) {
+      weeklyCalendar = AsyncState.success(_weeklyCalendarCache!);
+      notifyListeners();
+      return;
+    }
     weeklyCalendar = const AsyncState.loading();
     notifyListeners();
 
@@ -220,6 +308,7 @@ class HomeViewModel with ChangeNotifier {
     var result = AppUtil.getCurrentWeek(_today);
 
     weeklyCalendar = AsyncState.success(result);
+    _weeklyCalendarCache = result;
     notifyListeners();
   }
 }

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -48,7 +48,7 @@ class HomeViewModel with ChangeNotifier {
   List<DateTime>? _weeklyCalendarCache;
   final Map<String, Map<String, List<ExhibitModel>>>
   _weeklyExhibitsBySelectedDateCache = {};
-  Map<String, List<String>> _genresCache = {};
+  final Map<String, List<String>> _genresCache = {};
   final Map<String, Map<String, List<ExhibitModel>>> _exhibitsByGenreCache = {};
 
   final DateTime _today = DateTime.now();

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -18,14 +18,26 @@ class HomeViewModel with ChangeNotifier {
   AsyncState<List<String>> domesticRegions = const AsyncState.loading();
   AsyncState<List<ExhibitModel>> todayExhibitRecommendations =
       const AsyncState.loading();
-  AsyncState<List<String>> genres = const AsyncState.loading();
-  AsyncState<List<ExhibitModel>> exhibitsByGenre = const AsyncState.loading();
+  Map<String, AsyncState<List<String>>> genres = {
+    LocationType.overseas.name: const AsyncState.loading(),
+    LocationType.domestic.name: const AsyncState.loading(),
+  };
+  Map<String, AsyncState<List<ExhibitModel>>> exhibitsByGenre = {
+    LocationType.overseas.name: const AsyncState.loading(),
+    LocationType.domestic.name: const AsyncState.loading(),
+  };
   Map<String, AsyncState<List<ExhibitModel>>> personalizedExhibits = {
     LocationType.overseas.name: const AsyncState.loading(),
     LocationType.domestic.name: const AsyncState.loading(),
   };
-  Map<String, AsyncState<List<ExhibitModel>>> weeklyExhibitsBySelectedDate = {
-    DateTime.now().day.toString(): const AsyncState.loading(),
+  Map<String, Map<String, AsyncState<List<ExhibitModel>>>>
+  weeklyExhibitsBySelectedDate = {
+    LocationType.overseas.name: {
+      DateTime.now().day.toString(): const AsyncState.loading(),
+    },
+    LocationType.domestic.name: {
+      DateTime.now().day.toString(): const AsyncState.loading(),
+    },
   };
   AsyncState<List<DateTime>> weeklyCalendar = const AsyncState.loading();
 
@@ -34,9 +46,10 @@ class HomeViewModel with ChangeNotifier {
   final Map<String, List<ExhibitModel>> _todayExhibitRecommendationsCache = {};
   final Map<String, List<ExhibitModel>> _personalizedExhibitsCache = {};
   List<DateTime>? _weeklyCalendarCache;
-  final Map<String, List<ExhibitModel>> _weeklyExhibitsBySelectedDateCache = {};
-  List<String>? _genresCache;
-  final Map<String, List<ExhibitModel>> _exhibitsByGenreCache = {};
+  final Map<String, Map<String, List<ExhibitModel>>>
+  _weeklyExhibitsBySelectedDateCache = {};
+  Map<String, List<String>> _genresCache = {};
+  final Map<String, Map<String, List<ExhibitModel>>> _exhibitsByGenreCache = {};
 
   final DateTime _today = DateTime.now();
   bool _isDomestic = false;
@@ -48,6 +61,10 @@ class HomeViewModel with ChangeNotifier {
   String get selectedLocation => _selectedLocation;
   String get selectedGenre => _selectedGenre;
   DateTime get selectedDateInWeek => _selectedDateInWeek;
+  String get locationType =>
+      _isDomestic ? LocationType.domestic.name : LocationType.overseas.name;
+
+  List<String>? get domesticRegionsCache => _domesticRegionsCache;
 
   set isDomestic(bool value) {
     _isDomestic = value;
@@ -72,13 +89,13 @@ class HomeViewModel with ChangeNotifier {
   void _resetToLoading({bool resetLocations = true}) {
     if (resetLocations) overseasCountries = const AsyncState.loading();
     todayExhibitRecommendations = const AsyncState.loading();
-    genres = const AsyncState.loading();
-    exhibitsByGenre = const AsyncState.loading();
+    genres[locationType] = const AsyncState.loading();
+    exhibitsByGenre[locationType] = const AsyncState.loading();
     personalizedExhibits = {
       LocationType.overseas.name: const AsyncState.loading(),
       LocationType.domestic.name: const AsyncState.loading(),
     };
-    weeklyExhibitsBySelectedDate[_today.day.toString()] =
+    weeklyExhibitsBySelectedDate[locationType]![_today.day.toString()] =
         const AsyncState.loading();
     weeklyCalendar = const AsyncState.loading();
     notifyListeners();
@@ -184,36 +201,36 @@ class HomeViewModel with ChangeNotifier {
   }
 
   Future<void> fetchGenres() async {
-    if (_genresCache != null) {
-      _selectedGenre = _genresCache!.first;
-      genres = AsyncState.success(_genresCache!);
+    if (_genresCache[locationType] != null) {
+      _selectedGenre = _genresCache[locationType]!.first;
+      genres[locationType] = AsyncState.success(_genresCache[locationType]!);
       notifyListeners();
       return;
     }
-    genres = const AsyncState.loading();
+    genres[locationType] = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchGenres();
     if (result == null) {
-      genres = const AsyncState.error();
+      genres[locationType] = const AsyncState.error();
     } else {
-      genres = AsyncState.success(result);
+      genres[locationType] = AsyncState.success(result);
       _selectedGenre = result.first;
-      _genresCache = result;
+      _genresCache[locationType] = result;
     }
     notifyListeners();
     await fetchExhibitsByGenre();
   }
 
   Future<void> fetchExhibitsByGenre() async {
-    if (_exhibitsByGenreCache[_selectedGenre] != null) {
-      exhibitsByGenre = AsyncState.success(
-        _exhibitsByGenreCache[_selectedGenre]!,
+    if (_exhibitsByGenreCache[locationType]?[_selectedGenre] != null) {
+      exhibitsByGenre[locationType] = AsyncState.success(
+        _exhibitsByGenreCache[locationType]![_selectedGenre]!,
       );
       notifyListeners();
       return;
     }
-    exhibitsByGenre = const AsyncState.loading();
+    exhibitsByGenre[locationType] = const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchExhibitsByGenre(
@@ -223,11 +240,11 @@ class HomeViewModel with ChangeNotifier {
       genre: _selectedGenre,
     );
     if (result == null) {
-      exhibitsByGenre = const AsyncState.error();
+      exhibitsByGenre[locationType] = const AsyncState.error();
     } else {
-      exhibitsByGenre = AsyncState.success(result);
+      exhibitsByGenre[locationType] = AsyncState.success(result);
       exhibitVM.initializeFromExhibits(result);
-      _exhibitsByGenreCache[_selectedGenre] = result;
+      (_exhibitsByGenreCache[locationType] ??= {})[_selectedGenre] = result;
     }
     notifyListeners();
   }
@@ -266,15 +283,18 @@ class HomeViewModel with ChangeNotifier {
     if (isInitialLoad) _selectedDateInWeek = _today;
     var selectedDateDay = _selectedDateInWeek.day.toString();
 
-    if (_weeklyExhibitsBySelectedDateCache[selectedDateDay] != null) {
-      weeklyExhibitsBySelectedDate[selectedDateDay] = AsyncState.success(
-        _weeklyExhibitsBySelectedDateCache[selectedDateDay]!,
-      );
+    if (_weeklyExhibitsBySelectedDateCache[locationType]?[selectedDateDay] !=
+        null) {
+      weeklyExhibitsBySelectedDate[locationType]![selectedDateDay] =
+          AsyncState.success(
+            _weeklyExhibitsBySelectedDateCache[locationType]![selectedDateDay]!,
+          );
       notifyListeners();
       return;
     }
 
-    weeklyExhibitsBySelectedDate[selectedDateDay] = const AsyncState.loading();
+    (weeklyExhibitsBySelectedDate[locationType] ??= {})[selectedDateDay] =
+        const AsyncState.loading();
     notifyListeners();
 
     var result = await homeRepository.fetchWeeklyExhibitsBySelectedDate(
@@ -284,13 +304,15 @@ class HomeViewModel with ChangeNotifier {
       date: AppUtil.formatDateYMD(date),
     );
     if (result == null) {
-      weeklyExhibitsBySelectedDate[selectedDateDay] = const AsyncState.error();
+      (weeklyExhibitsBySelectedDate[locationType] ??= {})[selectedDateDay] =
+          const AsyncState.error();
     } else {
-      weeklyExhibitsBySelectedDate[selectedDateDay] = AsyncState.success(
-        result,
-      );
+      (weeklyExhibitsBySelectedDate[locationType] ??=
+          {})[selectedDateDay] = AsyncState.success(result);
       exhibitVM.initializeFromExhibits(result);
-      _weeklyExhibitsBySelectedDateCache[selectedDateDay] = result;
+      (_weeklyExhibitsBySelectedDateCache[locationType] ??=
+              {})[selectedDateDay] =
+          result;
     }
     notifyListeners();
   }

--- a/lib/features/home/regional_exhibits_page.dart
+++ b/lib/features/home/regional_exhibits_page.dart
@@ -1,11 +1,13 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/common_appbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:provider/provider.dart';
 
 class RegionalExhibitsPage extends StatefulWidget {
   const RegionalExhibitsPage(this.regionName, {super.key});
@@ -17,11 +19,27 @@ class RegionalExhibitsPage extends StatefulWidget {
 }
 
 class _RegionalExhibitsPageState extends State<RegionalExhibitsPage> {
+  final ValueNotifier<String?> _regionName = ValueNotifier(null);
+
+  @override
+  void initState() {
+    super.initState();
+    _regionName.value = widget.regionName;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.gray0,
-      appBar: CommonAppBar(title: widget.regionName),
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(52.h),
+        child: ValueListenableBuilder(
+          valueListenable: _regionName,
+          builder: (context, regionName, _) {
+            return CommonAppBar(title: regionName);
+          },
+        ),
+      ),
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
@@ -43,7 +61,7 @@ class _RegionalExhibitsPageState extends State<RegionalExhibitsPage> {
                   ),
                   GestureDetector(
                     onTap: () {
-                      // TODO: 필터 기능 추가
+                      _showFilterBottomSheet(_regionName.value!);
                     },
                     child: SvgPicture.asset(
                       AppAssets.icFilter,
@@ -73,6 +91,100 @@ class _RegionalExhibitsPageState extends State<RegionalExhibitsPage> {
           ),
         ],
       ),
+    );
+  }
+
+  void _showFilterBottomSheet(String selectedRegion) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: AppColors.subLightGray,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadiusGeometry.only(
+          topLeft: Radius.circular(16.r),
+          topRight: Radius.circular(16.r),
+        ),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: 244.h),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8.h,
+            children: [
+              Container(
+                alignment: Alignment.centerRight,
+                margin: EdgeInsets.only(top: 16.h, right: 24.w, bottom: 8.h),
+                child: GestureDetector(
+                  onTap: () => Navigator.pop(context),
+                  child: SvgPicture.asset(
+                    AppAssets.icClose,
+                    width: 24.w,
+                    height: 24.w,
+                  ),
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 24.w),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 8.h,
+                  children: [
+                    ArtTripText.pretendard().body01Bold().build().text(
+                      context.l10n.domestic,
+                    ),
+                    Selector<HomeViewModel, List<String>>(
+                      selector: (_, vm) => vm.domesticRegionsCache!,
+                      builder: (context, domesticRegionsCache, _) {
+                        return Wrap(
+                          spacing: 12.w,
+                          runSpacing: 12.h,
+                          children: List.generate(domesticRegionsCache.length, (
+                            index,
+                          ) {
+                            var item = domesticRegionsCache[index];
+                            var isSelected = selectedRegion == item;
+                            return GestureDetector(
+                              onTap: () {
+                                _regionName.value = item;
+                                Navigator.pop(context);
+                              },
+                              child: Container(
+                                padding: EdgeInsets.symmetric(
+                                  vertical: 8.h,
+                                  horizontal: 20.w,
+                                ),
+                                decoration: BoxDecoration(
+                                  color:
+                                      isSelected
+                                          ? AppColors.primary300
+                                          : AppColors.gray0,
+                                  borderRadius: BorderRadius.circular(100),
+                                ),
+                                child:
+                                    isSelected
+                                        ? ArtTripText.pretendard()
+                                            .body01Bold()
+                                            .color(AppColors.textWhite)
+                                            .build()
+                                            .text(item)
+                                        : ArtTripText.pretendard()
+                                            .body01Light()
+                                            .build()
+                                            .text(item),
+                              ),
+                            );
+                          }),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/home/views/domestic_overseas_view.dart
+++ b/lib/features/home/views/domestic_overseas_view.dart
@@ -37,7 +37,7 @@ class _DomesticOverseasViewState extends State<DomesticOverseasView> {
       child: SizedBox(
         height: 64.h,
         child: Selector<HomeViewModel, AsyncState<List<String>>>(
-          selector: (_, vm) => vm.locations,
+          selector: (_, vm) => vm.overseasCountries,
           builder: (context, state, _) {
             return AsyncView(
               state: state,

--- a/lib/features/home/views/genre_exhibits_view.dart
+++ b/lib/features/home/views/genre_exhibits_view.dart
@@ -1,6 +1,7 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/enum.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
@@ -42,7 +43,11 @@ class _GenreExhibitsViewState extends State<GenreExhibitsView> {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
       child: Selector<HomeViewModel, AsyncState<List<String>>>(
-        selector: (_, vm) => vm.genres,
+        selector:
+            (_, vm) =>
+                vm.genres[vm.isDomestic
+                    ? LocationType.domestic.name
+                    : LocationType.overseas.name]!,
         builder: (context, state, _) {
           return AsyncView(
             state: state,
@@ -83,7 +88,11 @@ class _GenreExhibitsViewState extends State<GenreExhibitsView> {
 
                     /// 장르별 랜덤 전시
                     Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
-                      selector: (_, vm) => vm.exhibitsByGenre,
+                      selector:
+                          (_, vm) =>
+                              vm.exhibitsByGenre[vm.isDomestic
+                                  ? LocationType.domestic.name
+                                  : LocationType.overseas.name]!,
                       builder: (context, state, _) {
                         return AsyncView(
                           state: state,

--- a/lib/features/home/views/personalized_exhibits_view.dart
+++ b/lib/features/home/views/personalized_exhibits_view.dart
@@ -18,9 +18,7 @@ import 'package:provider/provider.dart';
 import 'package:shimmer_animation/shimmer_animation.dart';
 
 class PersonalizedExhibitsView extends StatefulWidget {
-  const PersonalizedExhibitsView(this.isDomestic, {super.key});
-
-  final bool isDomestic;
+  const PersonalizedExhibitsView({super.key});
 
   @override
   State<PersonalizedExhibitsView> createState() =>
@@ -34,7 +32,7 @@ class _PersonalizedExhibitsViewState extends State<PersonalizedExhibitsView> {
       child: Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
         selector:
             (_, vm) =>
-                vm.personalizedExhibits[widget.isDomestic
+                vm.personalizedExhibits[vm.isDomestic
                     ? LocationType.domestic.name
                     : LocationType.overseas.name]!,
         builder: (context, state, _) {

--- a/lib/features/home/views/personalized_exhibits_view.dart
+++ b/lib/features/home/views/personalized_exhibits_view.dart
@@ -1,6 +1,7 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/app_consts.dart';
+import 'package:arttrip/core/enum.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/exhibit/viewmodel/exhibit_viewmodel.dart';
@@ -17,7 +18,9 @@ import 'package:provider/provider.dart';
 import 'package:shimmer_animation/shimmer_animation.dart';
 
 class PersonalizedExhibitsView extends StatefulWidget {
-  const PersonalizedExhibitsView({super.key});
+  const PersonalizedExhibitsView(this.isDomestic, {super.key});
+
+  final bool isDomestic;
 
   @override
   State<PersonalizedExhibitsView> createState() =>
@@ -29,7 +32,11 @@ class _PersonalizedExhibitsViewState extends State<PersonalizedExhibitsView> {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
       child: Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
-        selector: (_, vm) => vm.personalizedExhibits,
+        selector:
+            (_, vm) =>
+                vm.personalizedExhibits[widget.isDomestic
+                    ? LocationType.domestic.name
+                    : LocationType.overseas.name]!,
         builder: (context, state, _) {
           return AsyncView(
             state: state,

--- a/lib/features/home/views/regional_exhibits_view.dart
+++ b/lib/features/home/views/regional_exhibits_view.dart
@@ -24,7 +24,7 @@ class _RegionalExhibitsViewState extends State<RegionalExhibitsView> {
       padding: EdgeInsetsGeometry.only(top: 32.h),
       sliver: SliverToBoxAdapter(
         child: Selector<HomeViewModel, AsyncState<List<String>>>(
-          selector: (_, vm) => vm.locations,
+          selector: (_, vm) => vm.domesticRegions,
           builder: (context, state, _) {
             return AsyncView(
               state: state,

--- a/lib/features/home/views/today_exhibits_recommendation_view.dart
+++ b/lib/features/home/views/today_exhibits_recommendation_view.dart
@@ -13,7 +13,9 @@ import 'package:provider/provider.dart';
 import 'package:shimmer_animation/shimmer_animation.dart';
 
 class TodayExhibitsRecommendationView extends StatefulWidget {
-  const TodayExhibitsRecommendationView({super.key});
+  const TodayExhibitsRecommendationView(this.isDomestic, {super.key});
+
+  final bool isDomestic;
 
   @override
   State<TodayExhibitsRecommendationView> createState() =>
@@ -54,7 +56,8 @@ class _TodayExhibitsRecommendationViewState
                               item: item,
                               isFavorite: isFavorite,
                               location:
-                                  selectedLocation == context.l10n.allItems
+                                  (selectedLocation == context.l10n.allItems &&
+                                          !widget.isDomestic)
                                       ? item.countryName ?? item.regionName
                                       : null,
                               onTap:

--- a/lib/features/home/views/weekly_exhibits_schedule_view.dart
+++ b/lib/features/home/views/weekly_exhibits_schedule_view.dart
@@ -2,6 +2,7 @@ import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/app_consts.dart';
 import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/enum.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
@@ -44,7 +45,9 @@ class _WeeklyExhibitsScheduleViewState
                   Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
                     selector:
                         (_, vm) =>
-                            vm.weeklyExhibitsBySelectedDate[vm
+                            vm.weeklyExhibitsBySelectedDate[vm.isDomestic
+                                ? LocationType.domestic.name
+                                : LocationType.overseas.name]![vm
                                 .selectedDateInWeek
                                 .day
                                 .toString()]!,

--- a/lib/features/home/views/weekly_exhibits_schedule_view.dart
+++ b/lib/features/home/views/weekly_exhibits_schedule_view.dart
@@ -42,7 +42,12 @@ class _WeeklyExhibitsScheduleViewState
                   _buildHeader(),
                   _buildWeeklyCalendar(currentWeek),
                   Selector<HomeViewModel, AsyncState<List<ExhibitModel>>>(
-                    selector: (_, vm) => vm.weeklyExhibitsBySelectedDate,
+                    selector:
+                        (_, vm) =>
+                            vm.weeklyExhibitsBySelectedDate[vm
+                                .selectedDateInWeek
+                                .day
+                                .toString()]!,
                     builder: (context, state, _) {
                       return AsyncView(
                         state: state,

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -9,6 +9,7 @@
   "loginKakao": "카카오로 로그인",
   "loginGoogle": "Google로 로그인",
   "loginApple": "Apple로 로그인",
+  "domestic": "국내",
   "domesticExhibition": "국내전시",
   "internationalExhibition": "해외전시",
   "allItems": "전체",

--- a/lib/shared/widgets/common_appbar.dart
+++ b/lib/shared/widgets/common_appbar.dart
@@ -53,5 +53,5 @@ class CommonAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => Size.fromHeight(52.h);
 }


### PR DESCRIPTION
## Summary
- 홈 화면 데이터 캐싱 처리 (초기 데이터 로드 때만 로딩 뷰, 이후는 캐시 데이터 표시)
- 해외전시 / 국내전시 enum 타입 추가
- 지역별 전체 전시 리스트 화면 필터 기능 추가

## Demo
![화면 기록 2025-12-23 오후 5 15 41](https://github.com/user-attachments/assets/8b9963c6-4f17-4e1f-a31b-83a51483aaf9)

<br><br>

https://github.com/user-attachments/assets/e3be7d11-701f-4c27-bffd-1fb5bdbfbde1
