### PR TITLE
feat: 전시 상세 페이지 지도 탭 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ app.*.map.json
 
 # Environment variables
 .env
+ios/Flutter/GoogleMaps.xcconfig
 
 # Docs
 /docs/devtools_options.yaml

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+#include "GoogleMaps.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include "GoogleMaps.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '13.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,6 +4,17 @@ PODS:
   - Flutter (1.0.0)
   - flutter_native_splash (2.4.3):
     - Flutter
+  - Google-Maps-iOS-Utils (5.0.0):
+    - GoogleMaps (~> 8.0)
+  - google_maps_flutter_ios (0.0.1):
+    - Flutter
+    - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
+    - GoogleMaps (< 10.0, >= 8.4)
+  - GoogleMaps (8.4.0):
+    - GoogleMaps/Maps (= 8.4.0)
+  - GoogleMaps/Base (8.4.0)
+  - GoogleMaps/Maps (8.4.0):
+    - GoogleMaps/Base
   - image_picker_ios (0.0.1):
     - Flutter
   - kakao_flutter_sdk_common (1.9.7-3):
@@ -24,12 +35,18 @@ DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+
+SPEC REPOS:
+  trunk:
+    - Google-Maps-iOS-Utils
+    - GoogleMaps
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -38,6 +55,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  google_maps_flutter_ios:
+    :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   kakao_flutter_sdk_common:
@@ -55,6 +74,9 @@ SPEC CHECKSUMS:
   connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
+  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
+  google_maps_flutter_ios: e31555a04d1986ab130f2b9f24b6cdc861acc6d3
+  GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   kakao_flutter_sdk_common: 3dc8492c202af7853585d151490b1c5c6b7576cb
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
@@ -62,6 +84,6 @@ SPEC CHECKSUMS:
   sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
-PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
+PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				BDE57314CA827D2BACE1EC52 /* [CP] Embed Pods Frameworks */,
+				EA93824C642AD22E3CE14221 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -343,6 +344,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EA93824C642AD22E3CE14221 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FC0B01D2EDFB036D68CC144D /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import GoogleMaps
 import UIKit
 
 @main
@@ -7,6 +8,10 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Info.plist에서 Google Maps API 키 읽기
+    if let apiKey = Bundle.main.object(forInfoDictionaryKey: "GoogleMapsApiKey") as? String {
+      GMSServices.provideAPIKey(apiKey)
+    }
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -54,6 +54,7 @@
 			<string>kakaokompassauth</string>
 			<string>kakaolink</string>
 			<string>kakaoplus</string>
+			<string>comgooglemaps</string>
 		</array>
 		<key>CFBundleURLTypes</key>
 		<array>
@@ -68,6 +69,8 @@
 		</array>
 		<key>NSPhotoLibraryUsageDescription</key>
 		<string>사진을 첨부하기 위해 갤러리 접근 권한이 필요합니다.</string>
+		<key>GoogleMapsApiKey</key>
+		<string>$(GOOGLE_MAPS_API_KEY)</string>
 		<!--스플래시 화면에서 상단 시스템바 아이콘 색상을 검정으로 고정-->
 		<key>UIStatusBarStyle</key>
     	<string>UIStatusBarStyleDarkContent</string>

--- a/lib/features/exhibit/data/exhibit_repository_mock.dart
+++ b/lib/features/exhibit/data/exhibit_repository_mock.dart
@@ -33,6 +33,8 @@ class ExhibitRepositoryMockImpl implements ExhibitRepository {
       hallAddress: '서울 강남구 역삼로 000 10층',
       hallOpeningHours: 'AM 10:30 - PM 19:00',
       hallPhone: '000 - 123 - 1234',
+      hallLatitude: 48.8606, // 루브르 박물관 테스트 좌표
+      hallLongitude: 2.3376,
     );
   }
 

--- a/lib/features/exhibit/data/models/exhibit_detail.dart
+++ b/lib/features/exhibit/data/models/exhibit_detail.dart
@@ -22,6 +22,8 @@ abstract class ExhibitDetail with _$ExhibitDetail {
     required String hallAddress,
     String? hallOpeningHours,
     String? hallPhone,
+    double? hallLatitude,
+    double? hallLongitude,
   }) = _ExhibitDetail;
 
   factory ExhibitDetail.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/exhibit/view/exhibit_detail_page.dart
+++ b/lib/features/exhibit/view/exhibit_detail_page.dart
@@ -1,10 +1,10 @@
 import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
-import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_detail.dart';
 import 'package:arttrip/features/exhibit/viewmodel/exhibit_detail_viewmodel.dart';
 import 'package:arttrip/features/exhibit/widgets/exhibit_detail_tab.dart';
 import 'package:arttrip/features/exhibit/widgets/exhibit_header_section.dart';
+import 'package:arttrip/features/exhibit/widgets/exhibit_map_tab.dart';
 import 'package:arttrip/features/exhibit/widgets/exhibit_poster_image.dart';
 import 'package:arttrip/features/exhibit/widgets/exhibit_review_tab.dart';
 import 'package:arttrip/features/exhibit/widgets/exhibit_tab_bar.dart';
@@ -172,7 +172,7 @@ class _ExhibitDetailPageState extends State<ExhibitDetailPage>
       case 0:
         return ExhibitDetailTabContent(exhibit: exhibit);
       case 1:
-        return ExhibitPlaceholderTabContent(label: context.l10n.exhibitMapTab);
+        return ExhibitMapTabContent(exhibit: exhibit);
       case 2:
         return ExhibitReviewTabContent(
           exhibitId: widget.exhibitId,

--- a/lib/features/exhibit/widgets/exhibit_map_tab.dart
+++ b/lib/features/exhibit/widgets/exhibit_map_tab.dart
@@ -1,0 +1,100 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/exhibit/data/models/exhibit_detail.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// 전시 지도 탭 콘텐츠
+class ExhibitMapTabContent extends StatelessWidget {
+  const ExhibitMapTabContent({super.key, required this.exhibit});
+
+  final ExhibitDetail exhibit;
+
+  @override
+  Widget build(BuildContext context) {
+    // 좌표가 없는 경우
+    if (exhibit.hallLatitude == null || exhibit.hallLongitude == null) {
+      return _buildNoMapPlaceholder(context);
+    }
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 16.h),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [_buildMapContainer(context)],
+      ),
+    );
+  }
+
+  Widget _buildNoMapPlaceholder(BuildContext context) {
+    return SizedBox(
+      height: 150.h,
+      child: Center(
+        child: ArtTripText.pretendard()
+            .body01Regular()
+            .color(AppColors.textTertiary)
+            .build()
+            .text(context.l10n.noMapInfo),
+      ),
+    );
+  }
+
+  Widget _buildMapContainer(BuildContext context) {
+    var lat = exhibit.hallLatitude!;
+    var lng = exhibit.hallLongitude!;
+    var position = LatLng(lat, lng);
+
+    return GestureDetector(
+      onTap: () => _openGoogleMaps(lat, lng),
+      child: Container(
+        width: double.infinity,
+        height: 220.h,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8.r),
+          border: Border.all(color: AppColors.gray100, width: 1),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8.r),
+          child: GoogleMap(
+            initialCameraPosition: CameraPosition(target: position, zoom: 15),
+            markers: {
+              Marker(
+                markerId: const MarkerId('exhibit_location'),
+                position: position,
+                infoWindow: InfoWindow(title: exhibit.hallName),
+              ),
+            },
+            zoomControlsEnabled: false,
+            mapToolbarEnabled: false,
+            myLocationButtonEnabled: false,
+            scrollGesturesEnabled: false,
+            zoomGesturesEnabled: false,
+            rotateGesturesEnabled: false,
+            tiltGesturesEnabled: false,
+            onTap: (_) => _openGoogleMaps(lat, lng),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openGoogleMaps(double lat, double lng) async {
+    // Google Maps 앱 URL 스킴 (iOS)
+    var appUrl = Uri.parse(
+      'comgooglemaps://?daddr=$lat,$lng&directionsmode=transit',
+    );
+
+    // 앱이 설치되어 있으면 앱으로, 아니면 웹으로
+    if (await canLaunchUrl(appUrl)) {
+      await launchUrl(appUrl);
+    } else {
+      var webUrl = Uri.parse(
+        'https://www.google.com/maps/dir/?api=1&destination=$lat,$lng',
+      );
+      await launchUrl(webUrl, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -60,5 +60,6 @@
   "weekdayWed": "수",
   "weekdayThu": "목",
   "weekdayFri": "금",
-  "weekdaySat": "토"
+  "weekdaySat": "토",
+  "noMapInfo": "지도 정보가 없습니다"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -469,6 +469,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.0.0"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      sha256: "5d410c32112d7c6eb7858d359275b2aa04778eed3e36c745aeae905fb2fa6468"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.0"
+  google_maps_flutter:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter
+      sha256: "819985697596a42e1054b5feb2f407ba1ac92262e02844a40168e742b9f36dca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      sha256: "7c7ff5b883b27bfdd0d52d91d89faf00858a6c1b33aeca0dc80faca64f389983"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.3"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      sha256: "115b03c2e637e74d084a78c0e1faf42884fcd8e65d1a9ce58d909ca5493afa32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.7"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      sha256: e8b1232419fcdd35c1fdafff96843f5a40238480365599d8ca661dde96d283dd
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.1"
+  google_maps_flutter_web:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_web
+      sha256: d416602944e1859f3cbbaa53e34785c223fa0a11eddb34a913c964c5cbb5d8cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.14+3"
   graphs:
     dependency: transitive
     description:
@@ -901,6 +949,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      sha256: "12669c4a913688a26555323fb9cec373d8f9fbe091f2d01c40c723b33caa8989"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   url_launcher: ^6.3.2
   image_picker: ^1.2.1
   table_calendar: ^3.2.0
+  google_maps_flutter: ^2.14.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- 전시 상세 페이지에 지도 탭 기능 추가
- Google Maps SDK 연동 및 iOS 네이티브 설정
- 지도 클릭 시 Google Maps 앱으로 길찾기 연동

## Changes
### 지도 탭 UI
- `ExhibitMapTabContent` 위젯 구현
- 지도 크기: width full, height 220, border-radius 8px
- 전시장 위치 마커 표시
- 좌표 없을 경우 "지도 정보가 없습니다" 표시

### Google Maps 연동
- `google_maps_flutter: ^2.14.0` 패키지 추가
- iOS 14.0+ 지원 (Podfile 업데이트)
- API 키 환경변수 처리 (xcconfig 방식)

### 길찾기 기능
- 지도 클릭 시 Google Maps 앱 실행 (대중교통 모드)
- 앱 미설치 시 웹 브라우저로 fallback

## Screenshots
<img src="https://github.com/user-attachments/assets/7a9303f3-73b7-424c-8713-c9b1df7a69e1" width="300" />

## Test Plan
- [x] 좌표가 있는 전시 상세 페이지에서 지도 표시 확인
- [x] 좌표가 없는 전시에서 "지도 정보가 없습니다" 표시 확인
- [x] 지도 클릭 시 Google Maps 앱 실행 확인
- [x] Google Maps 앱 미설치 시 웹으로 이동 확인