### PR TITLE
feat: 마이페이지 기능 확장 (나의 리뷰, 취향 분석)

### DIFF
--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -215,11 +215,12 @@ class HomeViewModel with ChangeNotifier {
     var result = await homeRepository.fetchGenres();
     if (result == null) {
       genres[locationType] = const AsyncState.error();
-    } else {
-      genres[locationType] = AsyncState.success(result);
-      _selectedGenre = result.first;
-      _genresCache[locationType] = result;
+      notifyListeners();
+      return;
     }
+    genres[locationType] = AsyncState.success(result);
+    _selectedGenre = result.first;
+    _genresCache[locationType] = result;
     notifyListeners();
     await fetchExhibitsByGenre();
   }

--- a/lib/features/my/data/models/my_review_model.dart
+++ b/lib/features/my/data/models/my_review_model.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'my_review_model.freezed.dart';
+part 'my_review_model.g.dart';
+
+@freezed
+abstract class MyReviewModel with _$MyReviewModel {
+  const MyReviewModel._();
+
+  const factory MyReviewModel({
+    required int reviewId,
+    required String reviewTitle,
+    required String visitDate,
+    required String content,
+    String? thumbnailUrl,
+    required String createdAt,
+  }) = _MyReviewModel;
+
+  factory MyReviewModel.fromJson(Map<String, dynamic> json) =>
+      _$MyReviewModelFromJson(json);
+}
+
+@freezed
+abstract class MyReviewListResponseModel with _$MyReviewListResponseModel {
+  const MyReviewListResponseModel._();
+
+  const factory MyReviewListResponseModel({
+    required List<MyReviewModel> reviews,
+    String? nextCursor,
+    required bool hasNext,
+    @Default(0) int totalCount,
+  }) = _MyReviewListResponseModel;
+
+  factory MyReviewListResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$MyReviewListResponseModelFromJson(json);
+}

--- a/lib/features/my/data/models/user_profile_model.dart
+++ b/lib/features/my/data/models/user_profile_model.dart
@@ -7,8 +7,11 @@ part 'user_profile_model.g.dart';
 abstract class UserProfileModel with _$UserProfileModel {
   const UserProfileModel._();
 
-  const factory UserProfileModel({String? nickName, String? profileImage}) =
-      _UserProfileModel;
+  const factory UserProfileModel({
+    String? nickName,
+    String? profileImage,
+    String? email,
+  }) = _UserProfileModel;
 
   factory UserProfileModel.fromJson(Map<String, dynamic> json) =>
       _$UserProfileModelFromJson(json);

--- a/lib/features/my/data/my_repository.dart
+++ b/lib/features/my/data/my_repository.dart
@@ -1,6 +1,7 @@
 import 'package:arttrip/core/app_utils.dart';
 import 'package:arttrip/core/network/dio_client.dart';
 import 'package:arttrip/core/network/models/api_response.dart';
+import 'package:arttrip/features/my/data/models/my_review_model.dart';
 import 'package:arttrip/features/my/data/models/user_profile_model.dart';
 import 'package:dio/dio.dart';
 import 'package:image_picker/image_picker.dart';
@@ -15,6 +16,17 @@ abstract class MyRepository {
 
   /// 닉네임 변경 - 성공 시 null, 실패 시 에러 메시지 반환
   Future<String?> updateNickname(String nickname);
+
+  /// 나의 리뷰 목록 조회
+  Future<MyReviewListResponseModel?> fetchMyReviews({
+    String? cursor,
+    int size = 10,
+    int width = 72,
+    int height = 72,
+  });
+
+  /// 리뷰 삭제
+  Future<bool> deleteReview(int reviewId);
 }
 
 class MyRepositoryImpl implements MyRepository {
@@ -94,5 +106,49 @@ class MyRepositoryImpl implements MyRepository {
       AppUtil.debugLog('updateNickname: $e');
     }
     return '닉네임 변경에 실패했습니다.';
+  }
+
+  @override
+  Future<MyReviewListResponseModel?> fetchMyReviews({
+    String? cursor,
+    int size = 10,
+    int width = 72,
+    int height = 72,
+  }) async {
+    try {
+      var queryParams = <String, dynamic>{
+        'size': size,
+        'w': width,
+        'h': height,
+      };
+      if (cursor != null) {
+        queryParams['cursor'] = cursor;
+      }
+      var response = await _dio.get(
+        '/reviews/all',
+        queryParameters: queryParams,
+      );
+      var apiResponse = ApiResponse<MyReviewListResponseModel>.fromJson(
+        response.dataOrNull,
+        (obj) =>
+            MyReviewListResponseModel.fromJson(obj as Map<String, dynamic>),
+      );
+      return apiResponse.result;
+    } catch (e) {
+      AppUtil.debugLog('fetchMyReviews: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> deleteReview(int reviewId) async {
+    try {
+      var response = await _dio.delete('/reviews/$reviewId');
+      var apiResponse = ApiResponse<void>.fromJson(response.dataOrNull, (_) {});
+      return apiResponse.isSuccess;
+    } catch (e) {
+      AppUtil.debugLog('deleteReview: $e');
+    }
+    return false;
   }
 }

--- a/lib/features/my/data/my_repository_mock.dart
+++ b/lib/features/my/data/my_repository_mock.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/features/my/data/models/my_review_model.dart';
 import 'package:arttrip/features/my/data/models/user_profile_model.dart';
 import 'package:arttrip/features/my/data/my_repository.dart';
 import 'package:image_picker/image_picker.dart';
@@ -32,5 +33,52 @@ class MyRepositoryMockImpl implements MyRepository {
   Future<String?> updateNickname(String nickname) async {
     await Future.delayed(const Duration(milliseconds: 500));
     return null; // 성공
+  }
+
+  @override
+  Future<MyReviewListResponseModel?> fetchMyReviews({
+    String? cursor,
+    int size = 10,
+    int width = 72,
+    int height = 72,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    return const MyReviewListResponseModel(
+      reviews: [
+        MyReviewModel(
+          reviewId: 1,
+          reviewTitle: 'Imagination in Bloom',
+          visitDate: '2025-12-05',
+          content: '가볍게 보기 좋아요!',
+          thumbnailUrl: null,
+          createdAt: '2025-12-05T10:00:00',
+        ),
+        MyReviewModel(
+          reviewId: 2,
+          reviewTitle: 'Imagination in Bloom',
+          visitDate: '2025-07-29',
+          content: '리뷰 내용입니다.',
+          thumbnailUrl: null,
+          createdAt: '2025-07-29T10:00:00',
+        ),
+        MyReviewModel(
+          reviewId: 3,
+          reviewTitle: 'Imagination in Bloom',
+          visitDate: '2025-07-29',
+          content: '리뷰 내용입니다.',
+          thumbnailUrl: null,
+          createdAt: '2025-07-29T10:00:00',
+        ),
+      ],
+      nextCursor: null,
+      hasNext: false,
+      totalCount: 25,
+    );
+  }
+
+  @override
+  Future<bool> deleteReview(int reviewId) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    return true;
   }
 }

--- a/lib/features/my/data/my_repository_mock.dart
+++ b/lib/features/my/data/my_repository_mock.dart
@@ -9,7 +9,11 @@ class MyRepositoryMockImpl implements MyRepository {
     int height = 100,
   }) async {
     await Future.delayed(const Duration(milliseconds: 500));
-    return const UserProfileModel(nickName: '이유지', profileImage: null);
+    return const UserProfileModel(
+      nickName: '이유지',
+      profileImage: null,
+      email: 'test@example.com',
+    );
   }
 
   @override

--- a/lib/features/my/viewmodels/my_viewmodel.dart
+++ b/lib/features/my/viewmodels/my_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/features/my/data/models/my_review_model.dart';
 import 'package:arttrip/features/my/data/models/user_profile_model.dart';
 import 'package:arttrip/features/my/data/my_repository.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
@@ -8,8 +9,21 @@ class MyViewModel with ChangeNotifier {
   MyViewModel(this._repository);
   final MyRepository _repository;
 
+  // 프로필 상태
   AsyncState<UserProfileModel> _profileState = const AsyncState.loading();
   AsyncState<UserProfileModel> get profileState => _profileState;
+
+  // 리뷰 상태
+  AsyncState<List<MyReviewModel>> _reviewsState = const AsyncState.loading();
+  String? _reviewNextCursor;
+  bool _hasNextReview = true;
+  bool _isLoadingMoreReviews = false;
+  int _reviewTotalCount = 0;
+
+  AsyncState<List<MyReviewModel>> get reviewsState => _reviewsState;
+  bool get hasNextReview => _hasNextReview;
+  bool get isLoadingMoreReviews => _isLoadingMoreReviews;
+  int get reviewTotalCount => _reviewTotalCount;
 
   Future<void> fetchUserProfile() async {
     _profileState = const AsyncState.loading();
@@ -53,5 +67,68 @@ class MyViewModel with ChangeNotifier {
       await fetchUserProfile();
     }
     return error;
+  }
+
+  // ===== 리뷰 관련 메서드 =====
+
+  Future<void> fetchMyReviews() async {
+    _reviewsState = const AsyncState.loading();
+    _reviewNextCursor = null;
+    _hasNextReview = true;
+    notifyListeners();
+
+    var response = await _repository.fetchMyReviews();
+    if (response != null) {
+      _reviewsState = AsyncState.success(response.reviews);
+      _reviewNextCursor = response.nextCursor;
+      _hasNextReview = response.hasNext;
+      _reviewTotalCount = response.totalCount;
+    } else {
+      _reviewsState = const AsyncState.error(error: '리뷰를 불러올 수 없습니다.');
+    }
+    notifyListeners();
+  }
+
+  Future<void> fetchMoreReviews() async {
+    if (_isLoadingMoreReviews || !_hasNextReview) return;
+
+    _isLoadingMoreReviews = true;
+    notifyListeners();
+
+    var response = await _repository.fetchMyReviews(cursor: _reviewNextCursor);
+    if (response != null) {
+      var currentReviews = _reviewsState.data ?? [];
+      _reviewsState = AsyncState.success([
+        ...currentReviews,
+        ...response.reviews,
+      ]);
+      _reviewNextCursor = response.nextCursor;
+      _hasNextReview = response.hasNext;
+    }
+
+    _isLoadingMoreReviews = false;
+    notifyListeners();
+  }
+
+  void resetReviews() {
+    _reviewsState = const AsyncState.loading();
+    _reviewNextCursor = null;
+    _hasNextReview = true;
+    _isLoadingMoreReviews = false;
+    _reviewTotalCount = 0;
+  }
+
+  Future<bool> deleteReview(int reviewId) async {
+    var success = await _repository.deleteReview(reviewId);
+    if (success) {
+      // 삭제 성공 시 리스트에서 제거
+      var currentReviews = _reviewsState.data ?? [];
+      _reviewsState = AsyncState.success(
+        currentReviews.where((r) => r.reviewId != reviewId).toList(),
+      );
+      _reviewTotalCount = _reviewTotalCount > 0 ? _reviewTotalCount - 1 : 0;
+      notifyListeners();
+    }
+    return success;
   }
 }

--- a/lib/features/my/views/edit_profile_page.dart
+++ b/lib/features/my/views/edit_profile_page.dart
@@ -60,10 +60,16 @@ class _EditProfilePageState extends State<EditProfilePage> {
                 },
               ),
               SizedBox(height: 24.h),
-              EditProfileField(
-                label: context.l10n.emailLabel,
-                valueColor: AppColors.textTertiary,
-                value: 'abcd1234@naver.com',
+              Selector<MyViewModel, AsyncState<UserProfileModel>>(
+                selector: (_, vm) => vm.profileState,
+                builder: (context, state, _) {
+                  var email = state.data?.email ?? widget.profile.email ?? '';
+                  return EditProfileField(
+                    label: context.l10n.emailLabel,
+                    valueColor: AppColors.textTertiary,
+                    value: email,
+                  );
+                },
               ),
             ],
           ),

--- a/lib/features/my/views/my_page.dart
+++ b/lib/features/my/views/my_page.dart
@@ -97,9 +97,7 @@ class MyPage extends StatelessWidget {
         SizedBox(height: 24.h),
         MyMenuItem(
           title: context.l10n.myReviews,
-          onTap: () {
-            // 나의 리뷰 (추후 구현)
-          },
+          onTap: () => Routes.push(context, '/my/reviews'),
         ),
         SizedBox(height: 24.h),
         MyMenuItem(

--- a/lib/features/my/views/my_page.dart
+++ b/lib/features/my/views/my_page.dart
@@ -104,9 +104,7 @@ class MyPage extends StatelessWidget {
         SizedBox(height: 24.h),
         MyMenuItem(
           title: context.l10n.myTasteAnalysis,
-          onTap: () {
-            // 나의 취향 분석 (추후 구현)
-          },
+          onTap: () => Routes.push(context, '/my/taste-analysis'),
         ),
         SizedBox(height: 24.h),
         MyMenuItem(

--- a/lib/features/my/views/my_reviews_page.dart
+++ b/lib/features/my/views/my_reviews_page.dart
@@ -1,0 +1,168 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/my/data/models/my_review_model.dart';
+import 'package:arttrip/features/my/viewmodels/my_viewmodel.dart';
+import 'package:arttrip/features/my/widgets/my_review_item.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/app_confirm_dialog.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/common_appbar.dart';
+import 'package:arttrip/shared/widgets/init_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+class MyReviewsPage extends StatefulWidget {
+  const MyReviewsPage({super.key});
+
+  @override
+  State<MyReviewsPage> createState() => _MyReviewsPageState();
+}
+
+class _MyReviewsPageState extends State<MyReviewsPage> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      context.read<MyViewModel>().fetchMoreReviews();
+    }
+  }
+
+  Future<void> _handleDelete(int reviewId) async {
+    var confirmed = await AppConfirmDialog.show(
+      context: context,
+      title: context.l10n.deleteReviewTitle,
+      content: Text(
+        context.l10n.deleteReviewContent,
+        textAlign: TextAlign.center,
+        style:
+            ArtTripText.pretendard()
+                .body01Regular()
+                .color(AppColors.textSecondary)
+                .build()
+                .style(),
+      ),
+      cancelText: context.l10n.cancel,
+      confirmText: context.l10n.deleteButton,
+    );
+
+    if (confirmed == true && mounted) {
+      await context.read<MyViewModel>().deleteReview(reviewId);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InitWidget(
+      init: () {
+        var vm = context.read<MyViewModel>();
+        vm.resetReviews();
+        vm.fetchMyReviews();
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.gray0,
+        appBar: CommonAppBar(
+          title: context.l10n.myReviewsTitle,
+          showBackButton: true,
+        ),
+        body: _buildReviewList(),
+      ),
+    );
+  }
+
+  Widget _buildReviewList() {
+    return Selector<MyViewModel, AsyncState<List<MyReviewModel>>>(
+      selector: (_, vm) => vm.reviewsState,
+      builder: (context, state, _) {
+        return AsyncView<List<MyReviewModel>>(
+          state: state,
+          onData: (reviews) {
+            if (reviews.isEmpty) {
+              return _buildEmptyState();
+            }
+            return _buildReviewItems(reviews);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: ArtTripText.pretendard()
+          .body01Regular()
+          .color(AppColors.textTertiary)
+          .build()
+          .text(context.l10n.noReviewsYet),
+    );
+  }
+
+  Widget _buildReviewItems(List<MyReviewModel> reviews) {
+    return Consumer<MyViewModel>(
+      builder: (context, vm, _) {
+        var isLoadingMore = vm.isLoadingMoreReviews;
+        var totalCount = vm.reviewTotalCount;
+        // +1 for header, +1 for loading indicator if loading
+        var itemCount = reviews.length + 1 + (isLoadingMore ? 1 : 0);
+
+        return ListView.builder(
+          controller: _scrollController,
+          itemCount: itemCount,
+          itemBuilder: (context, index) {
+            // 첫 번째 아이템: 총 개수
+            if (index == 0) {
+              return Padding(
+                padding: EdgeInsets.only(
+                  top: 16.h,
+                  bottom: 20.h,
+                  left: 24.w,
+                  right: 24.w,
+                ),
+                child: ArtTripText.pretendard()
+                    .title02Bold()
+                    .color(AppColors.textPrimary)
+                    .build()
+                    .text(context.l10n.totalCount(totalCount)),
+              );
+            }
+
+            // 마지막 아이템: 로딩 인디케이터
+            if (index == itemCount - 1 && isLoadingMore) {
+              return Padding(
+                padding: EdgeInsets.symmetric(vertical: 16.h),
+                child: const Center(child: CircularProgressIndicator()),
+              );
+            }
+
+            // 리뷰 아이템 (index - 1 because of header)
+            var reviewIndex = index - 1;
+            return Padding(
+              padding: EdgeInsets.fromLTRB(24.w, 0, 24.w, 24.h),
+              child: MyReviewItem(
+                review: reviews[reviewIndex],
+                onDelete: () => _handleDelete(reviews[reviewIndex].reviewId),
+                onEdit: () {
+                  // TODO: 수정 기능 구현
+                },
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/my/widgets/my_review_item.dart
+++ b/lib/features/my/widgets/my_review_item.dart
@@ -1,0 +1,135 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/my/data/models/my_review_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/app_cached_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 나의 리뷰 목록의 개별 아이템 위젯
+class MyReviewItem extends StatelessWidget {
+  const MyReviewItem({
+    super.key,
+    required this.review,
+    this.onDelete,
+    this.onEdit,
+  });
+
+  final MyReviewModel review;
+  final VoidCallback? onDelete;
+  final VoidCallback? onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildHeader(context),
+        SizedBox(height: 16.h),
+        _buildContentBox(),
+      ],
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(child: _buildInfo(context)),
+        SizedBox(width: 12.w),
+        _buildThumbnail(),
+      ],
+    );
+  }
+
+  Widget _buildInfo(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ArtTripText.pretendard()
+            .body01Bold()
+            .color(AppColors.textPrimary)
+            .build()
+            .text(review.reviewTitle),
+        SizedBox(height: 8.h),
+        ArtTripText.pretendard()
+            .body02Regular()
+            .color(AppColors.textTertiary)
+            .build()
+            .text(context.l10n.visitDateFormat(_formatDate(review.visitDate))),
+        SizedBox(height: 8.h),
+        _buildActionButtons(context),
+      ],
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context) {
+    return Row(
+      children: [
+        _buildActionButton(label: context.l10n.deleteButton, onTap: onDelete),
+        SizedBox(width: 8.w),
+        _buildActionButton(label: context.l10n.editButton, onTap: onEdit),
+      ],
+    );
+  }
+
+  Widget _buildActionButton({required String label, VoidCallback? onTap}) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 10.h),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.gray50),
+          borderRadius: BorderRadius.circular(4.r),
+        ),
+        child: ArtTripText.pretendard()
+            .body02Bold()
+            .color(AppColors.textPrimary)
+            .build()
+            .text(label),
+      ),
+    );
+  }
+
+  Widget _buildThumbnail() {
+    if (review.thumbnailUrl == null || review.thumbnailUrl!.isEmpty) {
+      return Container(
+        width: 72.w,
+        height: 72.h,
+        decoration: BoxDecoration(
+          color: AppColors.gray50,
+          borderRadius: BorderRadius.circular(8.r),
+        ),
+      );
+    }
+
+    return AppCachedImage(
+      imageUrl: review.thumbnailUrl!,
+      width: 72.w,
+      height: 72.h,
+      borderRadius: BorderRadius.circular(4.r),
+    );
+  }
+
+  Widget _buildContentBox() {
+    return Container(
+      width: double.infinity,
+      constraints: BoxConstraints(minHeight: 100.h),
+      padding: EdgeInsets.all(12.w),
+      decoration: BoxDecoration(
+        color: AppColors.subLightGray,
+        borderRadius: BorderRadius.circular(8.r),
+      ),
+      child: ArtTripText.pretendard()
+          .body01Regular()
+          .color(AppColors.textPrimary)
+          .build()
+          .text(review.content),
+    );
+  }
+
+  String _formatDate(String dateString) {
+    // "2025-12-05" -> "2025.12.05"
+    return dateString.replaceAll('-', '.');
+  }
+}

--- a/lib/features/onboarding/data/keywords_repository.dart
+++ b/lib/features/onboarding/data/keywords_repository.dart
@@ -5,6 +5,7 @@ import 'package:arttrip/shared/models/base_result_model.dart';
 
 abstract class KeywordModelsRepository {
   Future<List<KeywordModel>?> fetchAllKeywordModels();
+  Future<List<KeywordModel>?> fetchUserKeywords();
   Future<bool> saveKeywordModels(List<int> keywordIds);
 }
 
@@ -22,6 +23,21 @@ class KeywordModelsRepositoryImpl implements KeywordModelsRepository {
           .toList();
     } catch (e) {
       AppUtil.debugLog('fetchAllKeywordModels: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<KeywordModel>?> fetchUserKeywords() async {
+    try {
+      var response = await _dio.get('/auth/keywords');
+      var model = BaseResultModel.fromJson(response.dataOrNull);
+      if (model.result == null) return [];
+      return (model.result as List)
+          .map<KeywordModel>((e) => KeywordModel.fromJson(e))
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchUserKeywords: $e');
     }
     return null;
   }

--- a/lib/features/onboarding/data/keywords_repository_mock.dart
+++ b/lib/features/onboarding/data/keywords_repository_mock.dart
@@ -25,6 +25,17 @@ class KeywordModelsRepositoryMockImpl implements KeywordModelsRepository {
   }
 
   @override
+  Future<List<KeywordModel>?> fetchUserKeywords() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    // 테스트용: 일부 키워드가 이미 선택된 상태로 반환
+    return [
+      KeywordModel(keywordId: 2, name: '근대미술', type: 'GENRE'),
+      KeywordModel(keywordId: 5, name: '조각', type: 'GENRE'),
+      KeywordModel(keywordId: 8, name: '역동적인', type: 'STYLE'),
+    ];
+  }
+
+  @override
   Future<bool> saveKeywordModels(List<int> keywordIds) async {
     await Future.delayed(const Duration(milliseconds: 100));
     return true;

--- a/lib/features/onboarding/viewmodels/keywords_viewmodel.dart
+++ b/lib/features/onboarding/viewmodels/keywords_viewmodel.dart
@@ -22,7 +22,7 @@ class KeywordModelsViewModel with ChangeNotifier {
   String? get errorMessage => _errorMessage;
   bool get canSubmit => _selectedKeywordModelIds.isNotEmpty;
 
-  Future<void> fetchKeywordModels() async {
+  Future<void> fetchKeywordModels({bool loadUserSelection = false}) async {
     _isLoading = true;
     _errorMessage = null;
     notifyListeners();
@@ -32,6 +32,16 @@ class KeywordModelsViewModel with ChangeNotifier {
     if (keywords != null) {
       _genres = keywords.where((k) => k.isGenre).toList();
       _styles = keywords.where((k) => k.isStyle).toList();
+
+      // 수정 모드일 경우 기존 선택된 키워드 불러오기
+      if (loadUserSelection) {
+        var userKeywords = await repository.fetchUserKeywords();
+        if (userKeywords != null) {
+          for (var keyword in userKeywords) {
+            _selectedKeywordModelIds.add(keyword.keywordId);
+          }
+        }
+      }
     } else {
       _errorMessage = '키워드를 불러오는데 실패했습니다';
     }
@@ -67,5 +77,14 @@ class KeywordModelsViewModel with ChangeNotifier {
     notifyListeners();
 
     return success;
+  }
+
+  void reset() {
+    _selectedKeywordModelIds.clear();
+    _genres = [];
+    _styles = [];
+    _isLoading = true;
+    _isSaving = false;
+    _errorMessage = null;
   }
 }

--- a/lib/features/onboarding/views/keywords_page.dart
+++ b/lib/features/onboarding/views/keywords_page.dart
@@ -1,9 +1,11 @@
+import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
 import 'package:arttrip/features/onboarding/viewmodels/keywords_viewmodel.dart';
 import 'package:arttrip/features/onboarding/widgets/keyword_chip.dart';
 import 'package:arttrip/routes/routes.dart';
 import 'package:arttrip/shared/utils/snackbar_utils.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/common_appbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
@@ -11,8 +13,10 @@ import 'package:provider/provider.dart';
 /// 관심 키워드 선택 페이지
 ///
 /// 신규 사용자(firstLogin: true)가 최초 로그인 시 이동하는 온보딩 화면
+/// isEditMode: true이면 마이페이지에서 취향 수정 모드로 진입
 class KeywordModelsPage extends StatefulWidget {
-  const KeywordModelsPage({super.key});
+  const KeywordModelsPage({super.key, this.isEditMode = false});
+  final bool isEditMode;
 
   @override
   State<KeywordModelsPage> createState() => _KeywordModelsPageState();
@@ -30,7 +34,9 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<KeywordModelsViewModel>().fetchKeywordModels();
+      var vm = context.read<KeywordModelsViewModel>();
+      vm.reset();
+      vm.fetchKeywordModels(loadUserSelection: widget.isEditMode);
     });
   }
 
@@ -40,19 +46,28 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
 
     return Scaffold(
       backgroundColor: Colors.white,
+      appBar:
+          widget.isEditMode
+              ? CommonAppBar(
+                title: context.l10n.myTasteAnalysis,
+                showBackButton: true,
+              )
+              : const CommonAppBar(showBackButton: false),
       body: SafeArea(
+        bottom: false,
         child:
             vm.isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : Padding(
+                : SingleChildScrollView(
                   padding: EdgeInsets.symmetric(horizontal: 24.w),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       _buildHeader(),
                       _buildDivider(),
-                      Expanded(child: _buildContent(vm)),
+                      _buildContent(vm),
                       _buildSubmitButton(vm),
+                      SizedBox(height: 16.h),
                     ],
                   ),
                 ),
@@ -62,7 +77,7 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
 
   Widget _buildHeader() {
     return Padding(
-      padding: EdgeInsets.only(top: 32.h, bottom: 16.h),
+      padding: EdgeInsets.only(top: 16.h, bottom: 16.h),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -70,13 +85,13 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
               .headline()
               .color(_textColor)
               .build()
-              .text('관심있는 키워드를\n골라주세요!'),
+              .text(context.l10n.keywordSelectionTitle),
           SizedBox(height: 8.h),
           ArtTripText.pretendard()
               .body01Regular()
               .color(_textColor)
               .build()
-              .text('한 가지 이상 선택이 가능해요.'),
+              .text(context.l10n.keywordSelectionHint),
         ],
       ),
     );
@@ -87,18 +102,22 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
   }
 
   Widget _buildContent(KeywordModelsViewModel vm) {
-    return SingleChildScrollView(
+    return Padding(
       padding: EdgeInsets.symmetric(vertical: 24.h),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildSection(
-            title: '좋아하는 전시 장르는 무엇인가요?',
+            title: context.l10n.keywordGenreQuestion,
             keywords: vm.genres,
             vm: vm,
           ),
           SizedBox(height: 32.h),
-          _buildSection(title: '전시 스타일을 골라 주세요', keywords: vm.styles, vm: vm),
+          _buildSection(
+            title: context.l10n.keywordStyleQuestion,
+            keywords: vm.styles,
+            vm: vm,
+          ),
         ],
       ),
     );
@@ -182,7 +201,9 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
                     ),
                   )
                   : Text(
-                    '완료',
+                    widget.isEditMode
+                        ? context.l10n.save
+                        : context.l10n.complete,
                     style: TextStyle(
                       fontFamily: 'Pretendard',
                       fontSize: 16.sp,
@@ -201,11 +222,18 @@ class _KeywordModelsPageState extends State<KeywordModelsPage> {
 
     if (success) {
       if (mounted) {
-        Routes.go(context, '/');
+        if (widget.isEditMode) {
+          Navigator.pop(context);
+        } else {
+          Routes.go(context, '/');
+        }
       }
     } else {
       if (mounted) {
-        SnackBarUtils.showError(context, message: '키워드 저장에 실패했습니다');
+        SnackBarUtils.showError(
+          context,
+          message: context.l10n.keywordSaveError,
+        );
       }
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -73,5 +73,12 @@
   "deleteAccountTitle": "Delete Account",
   "deleteAccountContent": "When you leave ArtTrip, your data\n(favorites, reviews, stamps, etc.)\nwill be permanently deleted.",
   "deleteAccountQuestion": "Do you want to proceed?",
-  "deleteAccountButton": "Delete"
+  "deleteAccountButton": "Delete",
+  "save": "Save",
+  "complete": "Complete",
+  "keywordSelectionTitle": "Choose your\nfavorite keywords!",
+  "keywordSelectionHint": "You can select one or more.",
+  "keywordGenreQuestion": "What exhibition genres do you like?",
+  "keywordStyleQuestion": "Choose your exhibition style",
+  "keywordSaveError": "Failed to save keywords"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -80,5 +80,13 @@
   "keywordSelectionHint": "You can select one or more.",
   "keywordGenreQuestion": "What exhibition genres do you like?",
   "keywordStyleQuestion": "Choose your exhibition style",
-  "keywordSaveError": "Failed to save keywords"
+  "keywordSaveError": "Failed to save keywords",
+  "myReviewsTitle": "My Reviews",
+  "visitDateFormat": "Visited {date}",
+  "deleteButton": "Delete",
+  "editButton": "Edit",
+  "noReviewsYet": "No reviews yet.",
+  "totalCount": "{count} total",
+  "deleteReviewTitle": "Delete this review?",
+  "deleteReviewContent": "Deleted reviews cannot be restored,\nand stamps will also be deleted."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -103,5 +103,12 @@
   "keywordSelectionHint": "한 가지 이상 선택이 가능해요.",
   "keywordGenreQuestion": "좋아하는 전시 장르는 무엇인가요?",
   "keywordStyleQuestion": "전시 스타일을 골라 주세요",
-  "keywordSaveError": "키워드 저장에 실패했습니다"
+  "keywordSaveError": "키워드 저장에 실패했습니다",
+  "myReviewsTitle": "나의 리뷰",
+  "visitDateFormat": "{date} 방문",
+  "deleteButton": "삭제하기",
+  "editButton": "수정하기",
+  "noReviewsYet": "작성한 리뷰가 없습니다.",
+  "deleteReviewTitle": "리뷰를 삭제하시겠습니까?",
+  "deleteReviewContent": "삭제한 리뷰는 복구할 수 없으며,\n스탬프도 함께 삭제됩니다."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -96,5 +96,12 @@
   "selectCountryAndDate": "국가 및 날짜 선택",
   "country": "국가",
   "date": "날짜",
-  "apply": "적용하기"
+  "apply": "적용하기",
+  "save": "저장하기",
+  "complete": "완료",
+  "keywordSelectionTitle": "관심있는 키워드를\n골라주세요!",
+  "keywordSelectionHint": "한 가지 이상 선택이 가능해요.",
+  "keywordGenreQuestion": "좋아하는 전시 장르는 무엇인가요?",
+  "keywordStyleQuestion": "전시 스타일을 골라 주세요",
+  "keywordSaveError": "키워드 저장에 실패했습니다"
 }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -5,6 +5,7 @@ import 'package:arttrip/features/home/regional_exhibits_page.dart';
 import 'package:arttrip/features/login/login_page.dart';
 import 'package:arttrip/features/my/data/models/user_profile_model.dart';
 import 'package:arttrip/features/my/views/edit_profile_page.dart';
+import 'package:arttrip/features/my/views/my_reviews_page.dart';
 import 'package:arttrip/features/my/views/settings_page.dart';
 import 'package:arttrip/features/onboarding/views/keywords_page.dart';
 import 'package:arttrip/features/splash/views/splash_view.dart';
@@ -131,6 +132,14 @@ final appRouter = GoRouter(
           state,
           child: const KeywordModelsPage(isEditMode: true),
         );
+      },
+    ),
+
+    // 나의 리뷰 페이지
+    GoRoute(
+      path: '/my/reviews',
+      pageBuilder: (context, state) {
+        return buildPage(context, state, child: const MyReviewsPage());
       },
     ),
 

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -122,6 +122,18 @@ final appRouter = GoRouter(
       },
     ),
 
+    // 나의 취향 분석 페이지
+    GoRoute(
+      path: '/my/taste-analysis',
+      pageBuilder: (context, state) {
+        return buildPage(
+          context,
+          state,
+          child: const KeywordModelsPage(isEditMode: true),
+        );
+      },
+    ),
+
     // WebView 페이지 (개인정보 처리방침, 서비스 이용약관 등)
     GoRoute(
       path: '/webview',


### PR DESCRIPTION
## Summary
- 마이페이지의 '나의 리뷰' 페이지 구현
- 마이페이지의 '나의 취향 분석' 페이지 구현
- 사용자 프로필에 이메일 필드 추가

## Changes

### 나의 리뷰 페이지
- 리뷰 목록 조회 API 연동 (`GET /reviews/all`)
- 리뷰 삭제 기능 (`DELETE /reviews/{reviewId}`)
- 무한 스크롤 페이지네이션
- 삭제 시 확인 다이얼로그 표시

### 나의 취향 분석 페이지
- 기존 온보딩 키워드 선택 화면 재활용 (isEditMode)
- 사용자 기존 키워드 조회 API 연동
- 키워드 수정 기능

### 사용자 프로필
- UserProfileModel에 email 필드 추가
- 프로필 편집 페이지에서 이메일 표시

## New Files
- `lib/features/my/views/my_reviews_page.dart`
- `lib/features/my/widgets/my_review_item.dart`
- `lib/features/my/data/models/my_review_model.dart`

## Test Plan
- [x] 마이페이지 > 나의 리뷰 진입 확인
- [x] 리뷰 목록 스크롤 시 추가 로딩 확인
- [x] 리뷰 삭제 버튼 클릭 → 확인 다이얼로그 → 삭제 완료 확인
- [x] 마이페이지 > 나의 취향 분석 진입 확인
- [x] 기존 선택된 키워드 표시 확인
- [x] 키워드 수정 후 저장 확인
- [x] 프로필 편집에서 이메일 표시 확인