### PR TITLE
검색 페이지 구현 및 이미지 처리 개선

### DIFF
--- a/assets/svg/ic_delete.svg
+++ b/assets/svg/ic_delete.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="9" fill="#111111"/>
+<path d="M9 9L15 15" stroke="white" stroke-width="1.125" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 15L15 9.00001" stroke="white" stroke-width="1.125" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/core/app_assets.dart
+++ b/lib/core/app_assets.dart
@@ -32,6 +32,7 @@ class AppAssets {
   static const String icTablerWorld = 'assets/svg/ic_tabler_world.svg';
   static const String icReview = 'assets/svg/ic_review.svg';
   static const String icRecent = 'assets/svg/ic_recent.svg';
+  static const String icDelete = 'assets/svg/ic_delete.svg';
 
   // Logo
   static const String icLogoWhite = 'assets/svg/ic_logo_white.svg';

--- a/lib/core/app_consts.dart
+++ b/lib/core/app_consts.dart
@@ -1,7 +1,7 @@
 class AppConsts {
   const AppConsts._();
 
-  static const bool useMock = true; // Force using dummy data
+  static const bool useMock = false; // Force using dummy data
   static const int mockLoadingDelayMs =
       500; // Dummy data loading delay in milliseconds
 

--- a/lib/core/config/provider_config.dart
+++ b/lib/core/config/provider_config.dart
@@ -16,6 +16,9 @@ import 'package:arttrip/features/my/viewmodels/my_viewmodel.dart';
 import 'package:arttrip/features/onboarding/data/keywords_repository.dart';
 import 'package:arttrip/features/onboarding/data/keywords_repository_mock.dart';
 import 'package:arttrip/features/onboarding/viewmodels/keywords_viewmodel.dart';
+import 'package:arttrip/features/search/data/search_repository.dart';
+import 'package:arttrip/features/search/data/search_repository_mock.dart';
+import 'package:arttrip/features/search/viewmodels/search_viewmodel.dart';
 import 'package:arttrip/shared/viewmodels/alert_viewmodel.dart';
 import 'package:provider/provider.dart';
 
@@ -71,6 +74,14 @@ final getProviders = [
           AppConsts.useMock
               ? MyRepositoryMockImpl()
               : MyRepositoryImpl(DioClient.instance),
+        ),
+  ),
+  ChangeNotifierProvider<SearchViewModel>(
+    create:
+        (_) => SearchViewModel(
+          AppConsts.useMock
+              ? SearchRepositoryMockImpl()
+              : SearchRepositoryImpl(DioClient.instance),
         ),
   ),
 ];

--- a/lib/features/exhibit/data/models/exhibit_detail_model.dart
+++ b/lib/features/exhibit/data/models/exhibit_detail_model.dart
@@ -14,8 +14,8 @@ abstract class ExhibitDetailModel with _$ExhibitDetailModel {
     required int exhibitId,
     required String title,
     required String description,
-    required String posterUrl,
-    required String ticketUrl,
+    String? posterUrl,
+    String? ticketUrl,
     required String exhibitPeriod,
     required String status, // "ONGOING", "CLOSED", "UPCOMING"
     required String hallName,

--- a/lib/features/exhibit/data/models/write_review_params.dart
+++ b/lib/features/exhibit/data/models/write_review_params.dart
@@ -4,13 +4,13 @@
 /// exhibitId는 path parameter로 전달
 class WriteReviewParams {
   const WriteReviewParams({
-    required this.posterUrl,
+    this.posterUrl,
     required this.title,
     required this.hallName,
     this.reviewId,
   });
 
-  final String posterUrl;
+  final String? posterUrl;
   final String title;
   final String hallName;
 

--- a/lib/features/exhibit/viewmodels/write_review_viewmodel.dart
+++ b/lib/features/exhibit/viewmodels/write_review_viewmodel.dart
@@ -106,7 +106,7 @@ class WriteReviewViewModel with ChangeNotifier {
   }
 
   /// 상태 초기화 (신규 작성 모드)
-  void reset() {
+  void reset({bool notify = true}) {
     _visitDate = null;
     _content = '';
     _selectedImages.clear();
@@ -116,12 +116,12 @@ class WriteReviewViewModel with ChangeNotifier {
     _existingImages.clear();
     _deleteImageIds.clear();
     _isLoadingDetail = false;
-    notifyListeners();
+    if (notify) notifyListeners();
   }
 
   /// 수정 모드 초기화 - API로 리뷰 상세 조회
   Future<void> initForEdit({required int reviewId}) async {
-    reset();
+    reset(notify: false);
     _isEditMode = true;
     _reviewId = reviewId;
     _isLoadingDetail = true;

--- a/lib/features/exhibit/views/write_review_page.dart
+++ b/lib/features/exhibit/views/write_review_page.dart
@@ -8,13 +8,12 @@ import 'package:arttrip/features/exhibit/widgets/write_review/submit_review_butt
 import 'package:arttrip/features/exhibit/widgets/write_review/visit_date_section.dart';
 import 'package:arttrip/features/exhibit/widgets/write_review/write_review_header.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
-import 'package:arttrip/shared/widgets/init_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 
 /// 리뷰 작성/수정 페이지
-class WriteReviewPage extends StatelessWidget {
+class WriteReviewPage extends StatefulWidget {
   const WriteReviewPage({super.key, this.exhibitId = 0, required this.params});
 
   /// 신규 작성 시 필수, 수정 모드에서는 사용하지 않음
@@ -22,64 +21,71 @@ class WriteReviewPage extends StatelessWidget {
   final WriteReviewParams params;
 
   @override
+  State<WriteReviewPage> createState() => _WriteReviewPageState();
+}
+
+class _WriteReviewPageState extends State<WriteReviewPage> {
+  @override
+  void initState() {
+    super.initState();
+    final vm = context.read<WriteReviewViewModel>();
+    vm.reset(notify: false);
+    if (widget.params.isEditMode) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        vm.initForEdit(reviewId: widget.params.reviewId!);
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return InitWidget(
-      init: () {
-        final vm = context.read<WriteReviewViewModel>();
-        if (params.isEditMode) {
-          vm.initForEdit(reviewId: params.reviewId!);
-        } else {
-          vm.reset();
-        }
-      },
-      child: Scaffold(
+    return Scaffold(
+      backgroundColor: AppColors.gray0,
+      appBar: AppBar(
         backgroundColor: AppColors.gray0,
-        appBar: AppBar(
-          backgroundColor: AppColors.gray0,
-          elevation: 0,
-          scrolledUnderElevation: 0,
-          title: ArtTripText.pretendard()
-              .headline()
-              .color(AppColors.textPrimary)
-              .build()
-              .text(
-                params.isEditMode
-                    ? context.l10n.editReviewTitle
-                    : context.l10n.writeReviewTitle,
-              ),
-        ),
-        body: Column(
-          children: [
-            Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    WriteReviewHeader(params: params),
-                    const Divider(height: 1, color: AppColors.gray50),
-                    Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 24.w,
-                        vertical: 16.h,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const VisitDateSection(),
-                          SizedBox(height: 12.h),
-                          const PhotoAttachSection(),
-                          SizedBox(height: 12.h),
-                          const ReviewContentSection(),
-                        ],
-                      ),
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        title: ArtTripText.pretendard()
+            .headline()
+            .color(AppColors.textPrimary)
+            .build()
+            .text(
+              widget.params.isEditMode
+                  ? context.l10n.editReviewTitle
+                  : context.l10n.writeReviewTitle,
+            ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  WriteReviewHeader(params: widget.params),
+                  const Divider(height: 1, color: AppColors.gray50),
+                  Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 24.w,
+                      vertical: 16.h,
                     ),
-                    SubmitReviewButton(exhibitId: exhibitId),
-                  ],
-                ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const VisitDateSection(),
+                        SizedBox(height: 12.h),
+                        const PhotoAttachSection(),
+                        SizedBox(height: 12.h),
+                        const ReviewContentSection(),
+                      ],
+                    ),
+                  ),
+                  SubmitReviewButton(exhibitId: widget.exhibitId),
+                ],
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/exhibit/widgets/exhibit_header_section.dart
+++ b/lib/features/exhibit/widgets/exhibit_header_section.dart
@@ -30,7 +30,7 @@ class ExhibitHeaderSection extends StatelessWidget {
         _buildSubInfo(hallName),
         SizedBox(height: 4.h),
         _buildSubInfo(exhibitPeriod),
-        if (ticketUrl != null && ticketUrl!.isNotEmpty) ...[
+        if (ticketUrl?.isNotEmpty == true) ...[
           SizedBox(height: 16.h),
           _buildTicketButton(context),
         ],

--- a/lib/features/exhibit/widgets/exhibit_header_section.dart
+++ b/lib/features/exhibit/widgets/exhibit_header_section.dart
@@ -12,13 +12,13 @@ class ExhibitHeaderSection extends StatelessWidget {
     required this.title,
     required this.hallName,
     required this.exhibitPeriod,
-    required this.ticketUrl,
+    this.ticketUrl,
   });
 
   final String title;
   final String hallName;
   final String exhibitPeriod;
-  final String ticketUrl;
+  final String? ticketUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -30,8 +30,10 @@ class ExhibitHeaderSection extends StatelessWidget {
         _buildSubInfo(hallName),
         SizedBox(height: 4.h),
         _buildSubInfo(exhibitPeriod),
-        SizedBox(height: 16.h),
-        _buildTicketButton(context),
+        if (ticketUrl != null && ticketUrl!.isNotEmpty) ...[
+          SizedBox(height: 16.h),
+          _buildTicketButton(context),
+        ],
       ],
     );
   }
@@ -58,7 +60,7 @@ class ExhibitHeaderSection extends StatelessWidget {
       height: 52.h,
       child: ElevatedButton(
         onPressed: () async {
-          final uri = Uri.parse(ticketUrl);
+          final uri = Uri.parse(ticketUrl!);
           if (await canLaunchUrl(uri)) {
             await launchUrl(uri, mode: LaunchMode.externalApplication);
           }

--- a/lib/features/exhibit/widgets/exhibit_poster_image.dart
+++ b/lib/features/exhibit/widgets/exhibit_poster_image.dart
@@ -1,3 +1,4 @@
+import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/shared/widgets/app_cached_image.dart';
 import 'package:arttrip/shared/widgets/exhibit_status_badge.dart';
 import 'package:flutter/material.dart';
@@ -5,21 +6,33 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 /// 전시 포스터 이미지 위젯
 class ExhibitPosterImage extends StatelessWidget {
-  const ExhibitPosterImage({super.key, required this.posterUrl, this.status});
+  const ExhibitPosterImage({super.key, this.posterUrl, this.status});
 
-  final String posterUrl;
+  final String? posterUrl;
   final String? status;
 
   @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        AppCachedImage(
-          imageUrl: posterUrl,
-          width: double.infinity,
-          height: 276.h,
-          fit: BoxFit.cover,
-        ),
+        posterUrl != null
+            ? AppCachedImage(
+              imageUrl: posterUrl!,
+              width: double.infinity,
+              height: 276.h,
+              fit: BoxFit.cover,
+            )
+            : Container(
+              width: double.infinity,
+              height: 276.h,
+              color: AppColors.gray100,
+              child: const Center(
+                child: Icon(
+                  Icons.image_not_supported,
+                  color: AppColors.textTertiary,
+                ),
+              ),
+            ),
         if (status != null && status!.isNotEmpty)
           Positioned(
             top: 16.h,

--- a/lib/features/exhibit/widgets/write_review/photo_attach_section.dart
+++ b/lib/features/exhibit/widgets/write_review/photo_attach_section.dart
@@ -81,7 +81,11 @@ class PhotoAttachSection extends StatelessWidget {
     WriteReviewViewModel vm,
   ) async {
     final picker = ImagePicker();
-    final images = await picker.pickMultiImage();
+    final images = await picker.pickMultiImage(
+      maxWidth: 1024,
+      maxHeight: 1024,
+      imageQuality: 80,
+    );
     if (images.isNotEmpty) {
       vm.addImages(images);
     }

--- a/lib/features/exhibit/widgets/write_review/write_review_header.dart
+++ b/lib/features/exhibit/widgets/write_review/write_review_header.dart
@@ -17,12 +17,26 @@ class WriteReviewHeader extends StatelessWidget {
       padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 12.h),
       child: Row(
         children: [
-          AppCachedImage(
-            imageUrl: params.posterUrl,
-            width: 50.w,
-            height: 50.w,
-            borderRadius: BorderRadius.circular(4.r),
-          ),
+          params.posterUrl != null
+              ? AppCachedImage(
+                imageUrl: params.posterUrl!,
+                width: 50.w,
+                height: 50.w,
+                borderRadius: BorderRadius.circular(4.r),
+              )
+              : Container(
+                width: 50.w,
+                height: 50.w,
+                decoration: BoxDecoration(
+                  color: AppColors.gray100,
+                  borderRadius: BorderRadius.circular(4.r),
+                ),
+                child: Icon(
+                  Icons.image_not_supported,
+                  size: 20.w,
+                  color: AppColors.textTertiary,
+                ),
+              ),
           SizedBox(width: 16.w),
           Expanded(
             child: Column(

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -9,6 +9,7 @@ import 'package:arttrip/features/home/views/regional_exhibits_view.dart';
 import 'package:arttrip/features/home/views/today_exhibits_recommendation_view.dart';
 import 'package:arttrip/features/home/views/weekly_exhibits_schedule_view.dart';
 import 'package:arttrip/features/home/widgets/date_filter_bottom_sheet.dart';
+import 'package:arttrip/routes/routes.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/alert_badge.dart';
 import 'package:flutter/material.dart';
@@ -101,7 +102,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                         ),
                       ),
                     GestureDetector(
-                      onTap: () {},
+                      onTap: () => Routes.push(context, '/search'),
                       child: SvgPicture.asset(
                         AppAssets.icSearch,
                         width: 24.w,

--- a/lib/features/home/views/personalized_exhibits_view.dart
+++ b/lib/features/home/views/personalized_exhibits_view.dart
@@ -8,9 +8,9 @@ import 'package:arttrip/features/exhibit/viewmodels/exhibit_viewmodel.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
 import 'package:arttrip/routes/routes.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/app_cached_image.dart';
 import 'package:arttrip/shared/widgets/async_view.dart';
 import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -85,13 +85,23 @@ class _PersonalizedExhibitsViewState extends State<PersonalizedExhibitsView> {
                                   child: Stack(
                                     children: [
                                       item.posterUrl?.isNotEmpty == true
-                                          ? CachedNetworkImage(
+                                          ? AppCachedImage(
                                             imageUrl: item.posterUrl!,
                                             width: 120.w,
                                             height: 150.h,
                                             fit: BoxFit.cover,
                                           )
-                                          : const SizedBox.shrink(),
+                                          : Container(
+                                            width: 120.w,
+                                            height: 150.h,
+                                            color: AppColors.gray100,
+                                            child: const Center(
+                                              child: Icon(
+                                                Icons.image_not_supported,
+                                                color: AppColors.textTertiary,
+                                              ),
+                                            ),
+                                          ),
                                       location?.isNotEmpty == true
                                           ? Container(
                                             padding: EdgeInsets.symmetric(

--- a/lib/features/home/widgets/today_exhibit_widget.dart
+++ b/lib/features/home/widgets/today_exhibit_widget.dart
@@ -2,7 +2,7 @@ import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:arttrip/shared/widgets/app_cached_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -33,13 +33,23 @@ class TodayExhibitWidget extends StatelessWidget {
           children: [
             /// 백그라운드 이미지
             item.posterUrl?.isNotEmpty == true
-                ? CachedNetworkImage(
+                ? AppCachedImage(
                   imageUrl: item.posterUrl!,
                   width: 180.w,
                   height: 240.h,
                   fit: BoxFit.cover,
                 )
-                : const SizedBox.shrink(),
+                : Container(
+                  width: 180.w,
+                  height: 240.h,
+                  color: AppColors.gray100,
+                  child: const Center(
+                    child: Icon(
+                      Icons.image_not_supported,
+                      color: AppColors.textTertiary,
+                    ),
+                  ),
+                ),
 
             /// 테두리
             Container(

--- a/lib/features/my/views/edit_profile_page.dart
+++ b/lib/features/my/views/edit_profile_page.dart
@@ -186,14 +186,24 @@ class _EditProfilePageState extends State<EditProfilePage> {
   }
 
   Future<void> _pickImageFromGallery() async {
-    final image = await _picker.pickImage(source: ImageSource.gallery);
+    final image = await _picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 1024,
+      maxHeight: 1024,
+      imageQuality: 80,
+    );
     if (image != null) {
       await _uploadImage(image);
     }
   }
 
   Future<void> _pickImageFromCamera() async {
-    final image = await _picker.pickImage(source: ImageSource.camera);
+    final image = await _picker.pickImage(
+      source: ImageSource.camera,
+      maxWidth: 1024,
+      maxHeight: 1024,
+      imageQuality: 80,
+    );
     if (image != null) {
       await _uploadImage(image);
     }

--- a/lib/features/my/views/my_page.dart
+++ b/lib/features/my/views/my_page.dart
@@ -1,4 +1,3 @@
-import 'package:arttrip/core/app_assets.dart';
 import 'package:arttrip/core/app_colors.dart';
 import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/auth/services/auth_service.dart';
@@ -15,7 +14,6 @@ import 'package:arttrip/shared/widgets/init_widget.dart';
 import 'package:arttrip/shared/widgets/shimmer_skeleton_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer_animation/shimmer_animation.dart';
 
@@ -31,11 +29,7 @@ class MyPage extends StatelessWidget {
         appBar: CommonAppBar(
           title: context.l10n.myPageTitle,
           showBackButton: false,
-          actions: [
-            const AlertBadge(path: '/alerts'),
-            SizedBox(width: 20.w),
-            SvgPicture.asset(AppAssets.icSearch, width: 24.w, height: 24.w),
-          ],
+          actions: const [AlertBadge(path: '/alerts')],
         ),
         body: SingleChildScrollView(
           child: Column(

--- a/lib/features/search/data/models/search_history_model.dart
+++ b/lib/features/search/data/models/search_history_model.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'search_history_model.freezed.dart';
+part 'search_history_model.g.dart';
+
+/// 최근 검색어 모델
+@freezed
+abstract class SearchHistoryModel with _$SearchHistoryModel {
+  factory SearchHistoryModel({
+    required int searchHistoryId,
+    required String content,
+    required String createdAt,
+  }) = _SearchHistoryModel;
+
+  factory SearchHistoryModel.fromJson(Map<String, dynamic> json) =>
+      _$SearchHistoryModelFromJson(json);
+}

--- a/lib/features/search/data/search_repository.dart
+++ b/lib/features/search/data/search_repository.dart
@@ -1,0 +1,91 @@
+import 'package:arttrip/core/app_utils.dart';
+import 'package:arttrip/core/network/dio_client.dart';
+import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
+import 'package:arttrip/features/search/data/models/search_history_model.dart';
+
+abstract class SearchRepository {
+  Future<List<ExhibitModel>?> searchExhibits(String query);
+  Future<List<KeywordModel>?> fetchRecommendedKeywords();
+  Future<List<SearchHistoryModel>?> fetchSearchHistory();
+  Future<bool> deleteSearchHistory(int searchHistoryId);
+}
+
+class SearchRepositoryImpl implements SearchRepository {
+  SearchRepositoryImpl(this._dio);
+  final DioClient _dio;
+
+  @override
+  Future<List<ExhibitModel>?> searchExhibits(String query) async {
+    try {
+      final response = await _dio.get(
+        '/exhibits',
+        queryParameters: {'query': query},
+      );
+      final data = response.dataOrNull;
+      if (data == null) return null;
+      final map = data as Map<String, dynamic>;
+      final exhibits = map['exhibits'] as List?;
+      if (exhibits == null) return null;
+      return exhibits
+          .map<ExhibitModel>(
+            (e) => ExhibitModel.fromJson(e as Map<String, dynamic>),
+          )
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('searchExhibits: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<KeywordModel>?> fetchRecommendedKeywords() async {
+    try {
+      final response = await _dio.get('/keyword/recommand');
+      final data = response.dataOrNull;
+      if (data == null) return null;
+      final map = data as Map<String, dynamic>;
+      final keywords = map['keywords'] as List?;
+      if (keywords == null) return null;
+      return keywords
+          .map<KeywordModel>(
+            (e) => KeywordModel.fromJson(e as Map<String, dynamic>),
+          )
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchRecommendedKeywords: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<List<SearchHistoryModel>?> fetchSearchHistory() async {
+    try {
+      final response = await _dio.get('/search-history');
+      final data = response.dataOrNull;
+      if (data == null) return null;
+      final map = data as Map<String, dynamic>;
+      final items = map['items'] as List?;
+      if (items == null) return null;
+      return items
+          .map<SearchHistoryModel>(
+            (e) => SearchHistoryModel.fromJson(e as Map<String, dynamic>),
+          )
+          .toList();
+    } catch (e) {
+      AppUtil.debugLog('fetchSearchHistory: $e');
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> deleteSearchHistory(int searchHistoryId) async {
+    try {
+      final response = await _dio.delete('/search-history/$searchHistoryId');
+      return response.isSuccess;
+    } catch (e) {
+      AppUtil.debugLog('deleteSearchHistory: $e');
+    }
+    return false;
+  }
+}

--- a/lib/features/search/data/search_repository_mock.dart
+++ b/lib/features/search/data/search_repository_mock.dart
@@ -1,0 +1,96 @@
+import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
+import 'package:arttrip/features/search/data/models/search_history_model.dart';
+import 'package:arttrip/features/search/data/search_repository.dart';
+
+class SearchRepositoryMockImpl implements SearchRepository {
+  final List<ExhibitModel> _mockExhibits = [
+    ExhibitModel(
+      exhibitId: 1,
+      title: 'Imagination in Bloom',
+      posterUrl: 'https://picsum.photos/200/300',
+      status: 'ONGOING',
+      exhibitPeriod: '2025.07.29 ~ 2025.08.10',
+      hallName: '오르세 미술관',
+      countryName: '프랑스',
+    ),
+    ExhibitModel(
+      exhibitId: 2,
+      title: '현대미술의 흐름',
+      posterUrl: 'https://picsum.photos/200/301',
+      status: 'ONGOING',
+      exhibitPeriod: '2025.06.07 ~ 2025.09.14',
+      hallName: '서울시립미술관',
+      regionName: '서울',
+    ),
+    ExhibitModel(
+      exhibitId: 3,
+      title: '도자기의 미학',
+      posterUrl: 'https://picsum.photos/200/302',
+      status: 'UPCOMING',
+      exhibitPeriod: '2025.08.01 ~ 2025.10.31',
+      hallName: '경기도자미술관',
+      regionName: '경기',
+    ),
+  ];
+
+  final List<SearchHistoryModel> _mockHistory = [
+    SearchHistoryModel(
+      searchHistoryId: 1,
+      content: '독일',
+      createdAt: '2026-03-20',
+    ),
+    SearchHistoryModel(
+      searchHistoryId: 2,
+      content: '팝아트',
+      createdAt: '2026-03-19',
+    ),
+    SearchHistoryModel(
+      searchHistoryId: 3,
+      content: '현대 전시',
+      createdAt: '2026-03-18',
+    ),
+    SearchHistoryModel(
+      searchHistoryId: 4,
+      content: '디지털아트',
+      createdAt: '2026-03-17',
+    ),
+  ];
+
+  @override
+  Future<List<ExhibitModel>?> searchExhibits(String query) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    final lowerQuery = query.toLowerCase();
+    return _mockExhibits.where((e) {
+      return (e.title?.toLowerCase().contains(lowerQuery) ?? false) ||
+          (e.hallName?.toLowerCase().contains(lowerQuery) ?? false) ||
+          (e.countryName?.toLowerCase().contains(lowerQuery) ?? false) ||
+          (e.regionName?.toLowerCase().contains(lowerQuery) ?? false);
+    }).toList();
+  }
+
+  @override
+  Future<List<KeywordModel>?> fetchRecommendedKeywords() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      KeywordModel(keywordId: 1, name: '사진', type: 'GENRE'),
+      KeywordModel(keywordId: 2, name: '유럽 전시', type: 'STYLE'),
+      KeywordModel(keywordId: 3, name: '도자기', type: 'STYLE'),
+      KeywordModel(keywordId: 4, name: '현대', type: 'GENRE'),
+      KeywordModel(keywordId: 5, name: '아시아', type: 'STYLE'),
+    ];
+  }
+
+  @override
+  Future<List<SearchHistoryModel>?> fetchSearchHistory() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return List.from(_mockHistory);
+  }
+
+  @override
+  Future<bool> deleteSearchHistory(int searchHistoryId) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    _mockHistory.removeWhere((e) => e.searchHistoryId == searchHistoryId);
+    return true;
+  }
+}

--- a/lib/features/search/viewmodels/search_viewmodel.dart
+++ b/lib/features/search/viewmodels/search_viewmodel.dart
@@ -1,0 +1,103 @@
+import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
+import 'package:arttrip/features/search/data/models/search_history_model.dart';
+import 'package:arttrip/features/search/data/search_repository.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:flutter/foundation.dart';
+
+/// 검색 ViewModel
+class SearchViewModel extends ChangeNotifier {
+  SearchViewModel(this._repository);
+  final SearchRepository _repository;
+
+  // === State ===
+  List<SearchHistoryModel> _recentSearches = [];
+  AsyncState<List<KeywordModel>> _recommendedKeywords =
+      const AsyncState.loading();
+  AsyncState<List<ExhibitModel>> _searchResults = const AsyncState.success([]);
+  String _query = '';
+  bool _isSearchMode = false;
+
+  // === Getters ===
+  List<SearchHistoryModel> get recentSearches =>
+      List.unmodifiable(_recentSearches);
+  AsyncState<List<KeywordModel>> get recommendedKeywords =>
+      _recommendedKeywords;
+  AsyncState<List<ExhibitModel>> get searchResults => _searchResults;
+  String get query => _query;
+  bool get isSearchMode => _isSearchMode;
+
+  // === Actions ===
+
+  /// 초기 로드 (최근 검색어 + 추천 검색어)
+  Future<void> init() async {
+    final results = await Future.wait([
+      _repository.fetchSearchHistory(),
+      _repository.fetchRecommendedKeywords(),
+    ]);
+
+    final history = results[0] as List<SearchHistoryModel>?;
+    final keywords = results[1] as List<KeywordModel>?;
+
+    _recentSearches = history ?? [];
+
+    if (keywords != null) {
+      _recommendedKeywords = AsyncState.success(keywords);
+    } else {
+      _recommendedKeywords = const AsyncState.error();
+    }
+
+    notifyListeners();
+  }
+
+  /// 검색 실행
+  Future<void> search(String query) async {
+    _query = query;
+    _isSearchMode = true;
+    _searchResults = const AsyncState.loading();
+    notifyListeners();
+
+    final results = await _repository.searchExhibits(query);
+    if (results != null) {
+      _searchResults = AsyncState.success(results);
+    } else {
+      _searchResults = const AsyncState.error();
+    }
+    notifyListeners();
+  }
+
+  /// 검색 초기화 (초기 화면으로)
+  void clearSearch() {
+    _query = '';
+    _isSearchMode = false;
+    _searchResults = const AsyncState.success([]);
+    notifyListeners();
+  }
+
+  /// 최근 검색어 개별 삭제
+  Future<void> removeRecentSearch(int searchHistoryId) async {
+    _recentSearches.removeWhere((e) => e.searchHistoryId == searchHistoryId);
+    notifyListeners();
+    await _repository.deleteSearchHistory(searchHistoryId);
+  }
+
+  /// 최근 검색어 전체 삭제
+  Future<void> clearAllRecentSearches() async {
+    final ids = _recentSearches.map((e) => e.searchHistoryId).toList();
+    _recentSearches.clear();
+    notifyListeners();
+    for (final id in ids) {
+      await _repository.deleteSearchHistory(id);
+    }
+  }
+
+  /// 상태 초기화
+  void reset({bool notify = true}) {
+    _recentSearches = [];
+    _recommendedKeywords = const AsyncState.loading();
+    _searchResults = const AsyncState.success([]);
+    _query = '';
+    _isSearchMode = false;
+    if (notify) notifyListeners();
+  }
+}

--- a/lib/features/search/views/search_page.dart
+++ b/lib/features/search/views/search_page.dart
@@ -1,0 +1,166 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
+import 'package:arttrip/features/search/data/models/search_history_model.dart';
+import 'package:arttrip/features/search/viewmodels/search_viewmodel.dart';
+import 'package:arttrip/features/search/widgets/recent_search_section.dart';
+import 'package:arttrip/features/search/widgets/recommended_search_section.dart';
+import 'package:arttrip/features/search/widgets/search_input_field.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/async_view.dart';
+import 'package:arttrip/shared/widgets/common_appbar.dart';
+import 'package:arttrip/shared/widgets/exhibit_list_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+/// 검색 페이지
+class SearchPage extends StatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final vm = context.read<SearchViewModel>();
+    vm.reset(notify: false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      vm.init();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.gray0,
+      appBar: CommonAppBar(title: context.l10n.searchTitle),
+      body: Column(
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(24.w, 16.h, 24.w, 20.h),
+            child: SearchInputField(
+              controller: _controller,
+              onSearch: _onSearch,
+            ),
+          ),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    return Selector<SearchViewModel, bool>(
+      selector: (_, vm) => vm.isSearchMode,
+      builder: (context, isSearchMode, _) {
+        return isSearchMode ? _buildSearchResults() : _buildInitialView();
+      },
+    );
+  }
+
+  /// 초기 화면: 최근 검색어 + 추천 검색어
+  Widget _buildInitialView() {
+    return SizedBox(
+      width: double.infinity,
+      child: SingleChildScrollView(
+        padding: EdgeInsets.symmetric(horizontal: 24.w),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 최근 검색어
+            Selector<SearchViewModel, List<SearchHistoryModel>>(
+              selector: (_, vm) => vm.recentSearches,
+              builder: (context, recentSearches, _) {
+                if (recentSearches.isEmpty) return const SizedBox.shrink();
+                return Padding(
+                  padding: EdgeInsets.only(bottom: 32.h),
+                  child: RecentSearchSection(
+                    recentSearches: recentSearches,
+                    onTap: _onChipTap,
+                    onDelete: (id) {
+                      context.read<SearchViewModel>().removeRecentSearch(id);
+                    },
+                    onClearAll: () {
+                      context.read<SearchViewModel>().clearAllRecentSearches();
+                    },
+                  ),
+                );
+              },
+            ),
+            // 추천 검색어
+            Selector<SearchViewModel, AsyncState<List<KeywordModel>>>(
+              selector: (_, vm) => vm.recommendedKeywords,
+              builder: (context, state, _) {
+                return AsyncView<List<KeywordModel>>(
+                  state: state,
+                  onData: (keywords) {
+                    if (keywords.isEmpty) return const SizedBox.shrink();
+                    return RecommendedSearchSection(
+                      keywords: keywords,
+                      onTap: _onChipTap,
+                    );
+                  },
+                  onLoading: () => const SizedBox.shrink(),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 검색 결과
+  Widget _buildSearchResults() {
+    return Selector<SearchViewModel, AsyncState<List<ExhibitModel>>>(
+      selector: (_, vm) => vm.searchResults,
+      builder: (context, state, _) {
+        return AsyncView<List<ExhibitModel>>(
+          state: state,
+          onData: (exhibits) {
+            if (exhibits.isEmpty) return _buildEmptyState();
+            return ListView.separated(
+              padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 16.h),
+              itemCount: exhibits.length,
+              separatorBuilder: (_, _) => SizedBox(height: 16.h),
+              itemBuilder: (_, index) => ExhibitListItem(item: exhibits[index]),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: ArtTripText.pretendard()
+          .body01Regular()
+          .color(AppColors.textTertiary)
+          .build()
+          .text(context.l10n.noSearchResults),
+    );
+  }
+
+  void _onSearch(String query) {
+    context.read<SearchViewModel>().search(query.trim());
+  }
+
+  void _onChipTap(String keyword) {
+    _controller.text = keyword;
+    _controller.selection = TextSelection.collapsed(offset: keyword.length);
+    _onSearch(keyword);
+  }
+}

--- a/lib/features/search/widgets/recent_search_section.dart
+++ b/lib/features/search/widgets/recent_search_section.dart
@@ -1,0 +1,88 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/search/data/models/search_history_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// 최근 검색어 섹션
+class RecentSearchSection extends StatelessWidget {
+  const RecentSearchSection({
+    super.key,
+    required this.recentSearches,
+    required this.onTap,
+    required this.onDelete,
+    required this.onClearAll,
+  });
+
+  final List<SearchHistoryModel> recentSearches;
+  final Function(String) onTap;
+  final Function(int) onDelete;
+  final VoidCallback onClearAll;
+
+  @override
+  Widget build(BuildContext context) {
+    if (recentSearches.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ArtTripText.pretendard()
+                .title02Bold()
+                .color(AppColors.textPrimary)
+                .build()
+                .text(context.l10n.recentSearches),
+            GestureDetector(
+              onTap: onClearAll,
+              child: ArtTripText.pretendard()
+                  .body02Regular()
+                  .color(AppColors.textPrimary)
+                  .build()
+                  .text(context.l10n.clearAll),
+            ),
+          ],
+        ),
+        SizedBox(height: 12.h),
+        Wrap(
+          spacing: 8.w,
+          runSpacing: 8.h,
+          children: recentSearches.map((item) => _buildChip(item)).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChip(SearchHistoryModel item) {
+    return GestureDetector(
+      onTap: () => onTap(item.content),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 15.w, vertical: 8.h),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.gray100),
+          borderRadius: BorderRadius.circular(100.r),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ArtTripText.pretendard()
+                .body01Light()
+                .color(AppColors.textPrimary)
+                .build()
+                .text(item.content),
+            SizedBox(width: 8.w),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => onDelete(item.searchHistoryId),
+              child: SvgPicture.asset(AppAssets.icDelete),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/search/widgets/recommended_search_section.dart
+++ b/lib/features/search/widgets/recommended_search_section.dart
@@ -1,0 +1,58 @@
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/features/onboarding/data/models/keyword_model.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 추천 검색어 섹션
+class RecommendedSearchSection extends StatelessWidget {
+  const RecommendedSearchSection({
+    super.key,
+    required this.keywords,
+    required this.onTap,
+  });
+
+  final List<KeywordModel> keywords;
+  final Function(String) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (keywords.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ArtTripText.pretendard()
+            .title02Bold()
+            .color(AppColors.textPrimary)
+            .build()
+            .text(context.l10n.recommendedSearches),
+        SizedBox(height: 12.h),
+        Wrap(
+          spacing: 8.w,
+          runSpacing: 8.h,
+          children: keywords.map((keyword) => _buildChip(keyword)).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChip(KeywordModel keyword) {
+    return GestureDetector(
+      onTap: () => onTap(keyword.name),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 19.w, vertical: 11.h),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.gray100),
+          borderRadius: BorderRadius.circular(100.r),
+        ),
+        child: ArtTripText.pretendard()
+            .body01Bold()
+            .color(AppColors.textPoint)
+            .build()
+            .text(keyword.name),
+      ),
+    );
+  }
+}

--- a/lib/features/search/widgets/search_input_field.dart
+++ b/lib/features/search/widgets/search_input_field.dart
@@ -1,0 +1,69 @@
+import 'package:arttrip/core/app_assets.dart';
+import 'package:arttrip/core/app_colors.dart';
+import 'package:arttrip/core/extensions.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// 검색 입력 필드
+class SearchInputField extends StatelessWidget {
+  const SearchInputField({
+    super.key,
+    required this.controller,
+    required this.onSearch,
+  });
+
+  final TextEditingController controller;
+  final Function(String) onSearch;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: AppColors.gray100),
+        borderRadius: BorderRadius.circular(12.r),
+      ),
+      child: TextField(
+        controller: controller,
+        style:
+            ArtTripText.pretendard()
+                .body01Regular()
+                .color(AppColors.textPrimary)
+                .build()
+                .style(),
+        decoration: InputDecoration(
+          hintText: context.l10n.searchPlaceholder,
+          hintStyle:
+              ArtTripText.pretendard()
+                  .body01Regular()
+                  .color(AppColors.textTertiary)
+                  .build()
+                  .style(),
+          border: InputBorder.none,
+          contentPadding: EdgeInsets.symmetric(
+            horizontal: 16.w,
+            vertical: 14.h,
+          ),
+          suffixIcon: GestureDetector(
+            onTap: () => onSearch(controller.text),
+            child: Padding(
+              padding: EdgeInsets.only(right: 16.w),
+              child: SvgPicture.asset(
+                AppAssets.icSearch,
+                width: 24.w,
+                height: 24.w,
+              ),
+            ),
+          ),
+          suffixIconConstraints: BoxConstraints(
+            maxHeight: 24.w,
+            maxWidth: 40.w,
+          ),
+        ),
+        textInputAction: TextInputAction.search,
+        onSubmitted: onSearch,
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -95,5 +95,11 @@
   "editReviewTitle": "Edit Review",
   "updateReview": "Update",
   "reviewUpdateError": "Failed to update review",
-  "noRecentExhibits": "No recently viewed exhibitions."
+  "noRecentExhibits": "No recently viewed exhibitions.",
+  "searchTitle": "Search",
+  "searchPlaceholder": "Enter search keyword",
+  "noSearchResults": "No search results.",
+  "recentSearches": "Recent Searches",
+  "clearAll": "Clear All",
+  "recommendedSearches": "Recommended"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -117,5 +117,11 @@
   "editReviewTitle": "리뷰 수정",
   "updateReview": "수정하기",
   "reviewUpdateError": "리뷰 수정에 실패했습니다",
-  "noRecentExhibits": "최근 본 전시가 없습니다."
+  "noRecentExhibits": "최근 본 전시가 없습니다.",
+  "searchTitle": "검색하기",
+  "searchPlaceholder": "검색어를 입력해주세요",
+  "noSearchResults": "검색결과가 없습니다.",
+  "recentSearches": "최근 검색어",
+  "clearAll": "전체삭제",
+  "recommendedSearches": "추천 검색어"
 }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -9,6 +9,7 @@ import 'package:arttrip/features/my/views/my_reviews_page.dart';
 import 'package:arttrip/features/my/views/recent_exhibits_page.dart';
 import 'package:arttrip/features/my/views/settings_page.dart';
 import 'package:arttrip/features/onboarding/views/keywords_page.dart';
+import 'package:arttrip/features/search/views/search_page.dart';
 import 'package:arttrip/features/splash/views/splash_view.dart';
 import 'package:arttrip/routes/main_shell_route.dart';
 import 'package:arttrip/routes/route_builder.dart';
@@ -105,6 +106,14 @@ final appRouter = GoRouter(
           state,
           child: RegionalExhibitsPage(regionName),
         );
+      },
+    ),
+
+    // 검색 페이지
+    GoRoute(
+      path: '/search',
+      pageBuilder: (context, state) {
+        return buildPage(context, state, child: const SearchPage());
       },
     ),
 

--- a/lib/shared/widgets/exhibit_list_item.dart
+++ b/lib/shared/widgets/exhibit_list_item.dart
@@ -4,8 +4,8 @@ import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/exhibit/viewmodels/exhibit_viewmodel.dart';
 import 'package:arttrip/routes/routes.dart';
 import 'package:arttrip/shared/utils/text/arttrip_text.dart';
+import 'package:arttrip/shared/widgets/app_cached_image.dart';
 import 'package:arttrip/shared/widgets/exhibit_status_badge.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -31,13 +31,23 @@ class ExhibitListItem extends StatelessWidget {
                 children: [
                   /// 전시 이미지
                   item.posterUrl?.isNotEmpty == true
-                      ? CachedNetworkImage(
+                      ? AppCachedImage(
                         imageUrl: item.posterUrl!,
                         width: 100.w,
                         height: 100.w,
                         fit: BoxFit.cover,
                       )
-                      : const SizedBox.shrink(),
+                      : Container(
+                        width: 100.w,
+                        height: 100.w,
+                        color: AppColors.gray100,
+                        child: const Center(
+                          child: Icon(
+                            Icons.image_not_supported,
+                            color: AppColors.textTertiary,
+                          ),
+                        ),
+                      ),
 
                   /// 전시 상태
                   item.status != null

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -745,18 +745,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1198,10 +1198,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:
@@ -1435,5 +1435,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.32.0"


### PR DESCRIPTION
## Summary

### 검색 페이지 신규 구현
- 홈 화면 검색 아이콘을 통해 검색 페이지로 진입
- 전시 제목, 장소, 국가/지역 등 키워드 기반 전시 검색 기능 (`GET /exhibits?query=`)
- 최근 검색어 조회/개별 삭제/전체 삭제 (`GET /search-history`, `DELETE /search-history/{id}`)
- 추천 검색어 표시 (`GET /keyword/recommand`)
- 검색 결과가 없을 경우 안내 메시지 표시
- 추천/최근 검색어 칩 탭 시 해당 키워드로 즉시 검색

### 이미지 에러 처리 및 압축
- `CachedNetworkImage` 직접 사용을 `AppCachedImage`로 교체하여 이미지 로드 실패 시 플레이스홀더 표시 (404 에러 대응)
- 이미지가 없는 전시에 빈 공간 대신 플레이스홀더 UI 표시
- `image_picker`에 `maxWidth: 1024`, `maxHeight: 1024`, `imageQuality: 80` 옵션 추가하여 리뷰/프로필 이미지 업로드 시 413 에러 방지

### nullable 모델 수정
- `ExhibitDetailModel`의 `posterUrl`, `ticketUrl`을 nullable로 변경하여 API에서 null 반환 시 파싱 에러 방지
- `ticketUrl`이 null이면 홈페이지 버튼 숨김 처리

### 리뷰 작성 초기화 버그 수정
- 리뷰 작성 페이지 재진입 시 이전 데이터가 남아있는 문제 수정
- `WriteReviewPage`를 `StatefulWidget`으로 변경하여 `initState`에서 동기 초기화
- `reset(notify: false)` 패턴으로 빌드 중 `notifyListeners` 호출 방지

### 기타
- 마이페이지 검색 버튼 제거
- `useMock` 비활성화

## Test plan
- [x] 홈 화면 검색 아이콘 탭 → 검색 페이지 진입 확인
- [x] 검색어 입력 → 검색 결과 표시 / 빈 결과 시 안내 메시지 확인
- [x] 최근 검색어 칩 표시, 개별 삭제, 전체 삭제 동작 확인
- [x] 추천 검색어 칩 탭 → 해당 키워드로 검색 실행 확인
- [x] 검색 결과 카드 탭 → 전시 상세 페이지 이동 확인
- [x] 이미지 없는 전시에 플레이스홀더 표시 확인
- [ ] 리뷰 이미지 4장 업로드 시 413 에러 발생하지 않는지 확인
- [x] posterUrl이 null인 전시 상세 페이지 정상 표시 확인
- [x] 리뷰 작성 페이지 재진입 시 이전 데이터 초기화 확인
- [x] 리뷰 수정 모드 진입 시 기존 데이터 정상 로드 확인