### PR TITLE
온보딩 닉네임 단계 추가 및 리뷰·UX 개선

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -53,8 +53,8 @@ PODS:
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
-  - Google-Maps-iOS-Utils (5.0.0):
-    - GoogleMaps (~> 8.0)
+  - Google-Maps-iOS-Utils (6.1.0):
+    - GoogleMaps (~> 9.0)
   - google_maps_flutter_ios (0.0.1):
     - Flutter
     - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
@@ -67,11 +67,9 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleMaps (8.4.0):
-    - GoogleMaps/Maps (= 8.4.0)
-  - GoogleMaps/Base (8.4.0)
-  - GoogleMaps/Maps (8.4.0):
-    - GoogleMaps/Base
+  - GoogleMaps (9.4.0):
+    - GoogleMaps/Maps (= 9.4.0)
+  - GoogleMaps/Maps (9.4.0)
   - GoogleSignIn (9.1.0):
     - AppAuth (~> 2.0)
     - AppCheckCore (~> 11.0)
@@ -234,11 +232,11 @@ SPEC CHECKSUMS:
   flutter_local_notifications: eda81afddbf18f8589f6ec069ce593c4c6378769
   flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
   geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
-  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
+  Google-Maps-iOS-Utils: 0a484b05ed21d88c9f9ebbacb007956edd508a96
   google_maps_flutter_ios: e31555a04d1986ab130f2b9f24b6cdc861acc6d3
   google_sign_in_ios: 7336a3372ea93ea56a21e126a0055ffca3723601
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
+  GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238


### PR DESCRIPTION
## Summary

이번 PR은 온보딩 플로우 보강과 리뷰 작성/수정 경험 개선, 그리고 자잘한 UX 정리를 한 번에 묶어 정리했습니다.

### Onboarding
- 첫 로그인 플로우에 닉네임 입력 단계(Step 1/2) 추가, 키워드 선택을 Step 2/2로 정렬
- 키워드 선택 페이지의 헤더/시작하기 버튼 디자인을 신규 스펙에 맞게 갱신
- `MyRepository.updateNickname`이 서버 응답의 `message`를 그대로 노출하여 닉네임 형식/중복 등 구체 메시지를 화면에 표시

### Review write/edit
- 금칙어 응답(`REVIEW400-BAD_WORD_INCLUDED`) 전용 다이얼로그 추가, ApiResult 기반으로 분류
- 작성 성공/수정 성공 시 부모 화면에서 토스트 알림 표시
- 뒤로가기/X/iOS 스와이프 시 "작성 중단" 확인 다이얼로그(PopScope) 도입

### Account & Settings
- 회원 탈퇴 API 연동 + 카카오 unlink + 토큰 정리 흐름 구성
- 설정 화면의 알림 설정 페이지 UI 추가 (3개 토글, 로컬 상태)

### Map
- 바텀시트 리스트 스크롤 시 상단 드래그바가 사라지던 문제 수정 (SliverPersistentHeader pinned)

### 전시 상세
- 주소 하단에 "전시 장소는 변경될 수 있으므로 공식 홈페이지를 확인해주세요." 안내 문구 고정 표시

### Refactor / Chore
- 알림/토스트 메시지를 `AppToast`로 일괄 통일 (기존 `SnackBarUtils.showError` 호출 모두 교체)
- `ios/build/` 등 하위 build 디렉토리 gitignore 적용

## Test plan
- [ ] 신규 카카오 로그인 → 닉네임 입력(중복/형식 오류 메시지 노출) → 키워드 선택(2/2, 시작하기) → 홈
- [ ] 기존 사용자 로그인은 곧장 홈으로 이동
- [ ] 마이페이지 → 설정 → 알림 설정 진입, 토글 동작 확인
- [ ] 마이페이지 → 설정 → 회원 탈퇴, 다이얼로그 확인 후 탈퇴 → 로그인 화면 이동
- [ ] 전시 상세 → 리뷰 작성: 금칙어 포함 시 다이얼로그, 정상 등록 시 토스트, 뒤로가기 시 작성 중단 확인 다이얼로그
- [ ] 마이페이지 → 내 리뷰 → 수정: 정상 수정 시 토스트, 뒤로가기 다이얼로그
- [ ] 전시 상세 → 주소 하단에 안내 문구 노출
- [ ] 지도 탭 → 바텀시트 리스트 스크롤 시 상단 드래그바 고정
- [ ] 다국어(ko/en) 빌드 후 추가된 키 확인