### PR TITLE
fix: 홈 큐레이션 오버플로우 수정, 전시 정보 최대 2줄씩으로 수정, 릴리즈 버전 업

### DIFF
--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -401,6 +401,7 @@ class HomeViewModel with ChangeNotifier {
       _curations[_locationType] ??= {};
       _curations[_locationType]![_area[_locationType]!] =
           const AsyncState.loading();
+      notifyListeners();
 
       final result = await homeRepository.fetchCurations(
         isDomestic: isDomestic,
@@ -414,6 +415,7 @@ class HomeViewModel with ChangeNotifier {
       _curations[_locationType]?[_area[_locationType]!] =
           const AsyncState.error();
     }
+    notifyListeners();
   }
 
   /// 이번주 캘린더 조회

--- a/lib/features/home/pages/curation_detail_page.dart
+++ b/lib/features/home/pages/curation_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:arttrip/core/extensions.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_filter_model.dart';
 import 'package:arttrip/features/exhibit/data/models/exhibit_model.dart';
 import 'package:arttrip/features/home/home_viewmodel.dart';
+import 'package:arttrip/shared/utils/text/arttrip_text.dart';
 import 'package:arttrip/shared/widgets/alert_badge.dart';
 import 'package:arttrip/shared/widgets/common_appbar.dart';
 import 'package:arttrip/shared/widgets/exception_view.dart';
@@ -103,7 +104,14 @@ class _CurationDetailPageState extends State<CurationDetailPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CommonAppBar(
-        title: widget.title.isEmpty ? context.l10n.curationTitle : widget.title,
+        titleWidget: ArtTripText.pretendard()
+            .headline()
+            .ellipsis(2)
+            .textAlign(TextAlign.center)
+            .build()
+            .text(
+              widget.title.isEmpty ? context.l10n.curationTitle : widget.title,
+            ),
         actions: const [AlertBadge()],
       ),
       body: ValueListenableBuilder(

--- a/lib/features/home/views/curation_view.dart
+++ b/lib/features/home/views/curation_view.dart
@@ -154,9 +154,13 @@ class _CurationViewState extends State<CurationView> {
           spacing: 4.h,
           children: [
             Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                ArtTripText.pretendard().title01Bold().build().text(title),
-                const Expanded(child: SizedBox.shrink()),
+                Expanded(
+                  child: ArtTripText.pretendard().title01Bold().build().text(
+                    title,
+                  ),
+                ),
                 SvgPicture.asset(
                   AppAssets.icNoArrowRight,
                   width: 24.w,

--- a/lib/features/home/views/curation_view.dart
+++ b/lib/features/home/views/curation_view.dart
@@ -39,7 +39,7 @@ class _CurationViewState extends State<CurationView> {
             return Selector<HomeViewModel, AsyncState<CurationModel>>(
               selector: (_, vm) =>
                   vm.curations[vm.locationType]?[vm.area[vm.locationType]!] ??
-                  const AsyncState.error(),
+                  const AsyncState.loading(),
               builder: (context, state, _) {
                 return AsyncView(
                   state: state,
@@ -111,7 +111,9 @@ class _CurationViewState extends State<CurationView> {
                     );
                   },
                   onLoading: () => _buildCurationLoadingView(),
-                  onError: ({error}) => _buildEmptyView('', '', '0'),
+                  onError: ({error}) {
+                    return _buildEmptyView('', '', '0');
+                  },
                 );
               },
             );

--- a/lib/features/home/widgets/today_exhibit_widget.dart
+++ b/lib/features/home/widgets/today_exhibit_widget.dart
@@ -122,18 +122,21 @@ class TodayExhibitWidget extends StatelessWidget {
                       ArtTripText.pretendard()
                           .title02Bold()
                           .color(AppColors.textWhite)
+                          .ellipsis(2)
                           .build()
                           .text(item.title!),
                     if (item.hallName != null)
                       ArtTripText.pretendard()
                           .body02Regular()
                           .color(AppColors.textWhite)
+                          .ellipsis(2)
                           .build()
                           .text(item.hallName!),
                     if (item.exhibitPeriod?.isNotEmpty == true)
                       ArtTripText.pretendard()
                           .body02Regular()
                           .color(AppColors.textWhite)
+                          .ellipsis(2)
                           .build()
                           .text(item.exhibitPeriod!),
                   ],

--- a/lib/shared/widgets/exhibit_list_item.dart
+++ b/lib/shared/widgets/exhibit_list_item.dart
@@ -116,6 +116,7 @@ class ExhibitListItem extends StatelessWidget {
                     ArtTripText.pretendard()
                         .body01Regular()
                         .color(const Color(0xFF7859FF))
+                        .ellipsis(2)
                         .build()
                         .text(
                           !isDomestic
@@ -141,12 +142,14 @@ class ExhibitListItem extends StatelessWidget {
                         ArtTripText.pretendard()
                             .body02Regular()
                             .color(AppColors.textTertiary)
+                            .ellipsis(2)
                             .build()
                             .text(item.hallName ?? item.exhibitHallName!),
                       if (item.exhibitPeriod?.isNotEmpty == true)
                         ArtTripText.pretendard()
                             .body02Regular()
                             .color(AppColors.textTertiary)
+                            .ellipsis(2)
                             .build()
                             .text(item.exhibitPeriod!),
                     ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: arttrip
 description: "ArtTrip - Global Art Exhibition Booking App"
 publish_to: "none"
-version: 1.0.0+12
+version: 1.0.1+14
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: arttrip
 description: "ArtTrip - Global Art Exhibition Booking App"
 publish_to: "none"
-version: 1.0.1+14
+version: 1.0.1+16
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
## Summary
- 전시 정보에 국가/지역, 전시명, 전시홀명, 전시 기간을 최대 2줄로 표시되도록 수정
- 홈의 큐레이션 상단 제목이 오버플로우 되었던 오류 수정

## Demo
### exhibit info
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/089e435f-e867-41de-834a-ddc2d3d6b235" />

### curation
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/aad5bda8-b6b1-4279-999b-27f8a8aa67b5" />

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/aa134742-15df-4397-ae96-6366d0918c10" />
